### PR TITLE
Further MemPool Improvements

### DIFF
--- a/src/crypto/siphash.cpp
+++ b/src/crypto/siphash.cpp
@@ -171,3 +171,32 @@ uint64_t SipHashUint256Extra(uint64_t k0, uint64_t k1, const uint256& val, uint3
     SIPROUND;
     return v0 ^ v1 ^ v2 ^ v3;
 }
+
+#define ROTL32(x, b) (uint32_t)(((x) << (b)) | ((x) >> (32 - (b))))
+#define SIPROUND32 do { \
+    v0 += v1; v1 = ROTL32(v1, 7); v1 ^= v0; \
+    v0 = ROTL32(v0, 16); \
+    v2 += v3; v3 = ROTL32(v3, 8); v3 ^= v2; \
+    v0 += v3; v3 = ROTL32(v3, 11); v3 ^= v0; \
+    v2 += v1; v1 = ROTL32(v1, 9); v1 ^= v2; \
+    v2 = ROTL32(v2, 16); \
+} while (0)
+// see https://www.kernel.org/doc/html/latest/security/siphash.html#halfsiphash-siphash-s-insecure-younger-cousin
+uint32_t HalfSipHashUint32(uint64_t k, const uint32_t n)
+{
+    /* Specialized implementation for efficiency */
+    uint32_t v0 = 0;
+    uint32_t v1 = 0;
+    uint32_t v2 = 0x6c796765U ^ (k>>32);
+    uint32_t v3 = 0x74656462U ^ ((k<<32)>>32) ^ n;
+    SIPROUND32;
+    v0 ^= n;
+    v3 ^= 4<<24;
+    SIPROUND32;
+    v0 ^= 4<<24;
+    v2 ^= 0xff;
+    SIPROUND32;
+    SIPROUND32;
+    SIPROUND32;
+    return v1 ^ v3;
+}

--- a/src/crypto/siphash.h
+++ b/src/crypto/siphash.h
@@ -44,4 +44,8 @@ public:
 uint64_t SipHashUint256(uint64_t k0, uint64_t k1, const uint256& val);
 uint64_t SipHashUint256Extra(uint64_t k0, uint64_t k1, const uint256& val, uint32_t extra);
 
+// Specialized SipHash cousin for hashmaps using 32-bit keys that want Dos resistance
+// see https://www.kernel.org/doc/html/latest/security/siphash.html#halfsiphash-siphash-s-insecure-younger-cousin
+uint32_t HalfSipHashUint32(uint64_t k, const uint32_t n);
+
 #endif // BITCOIN_CRYPTO_SIPHASH_H

--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -307,7 +307,7 @@ public:
     {
         LockPoints lp;
         CTxMemPoolEntry entry(tx, 0, 0, 0, false, 0, lp);
-        CTxMemPool::setEntries ancestors;
+        CTxMemPool::vecEntries ancestors;
         auto limit_ancestor_count = gArgs.GetArg("-limitancestorcount", DEFAULT_ANCESTOR_LIMIT);
         auto limit_ancestor_size = gArgs.GetArg("-limitancestorsize", DEFAULT_ANCESTOR_SIZE_LIMIT) * 1000;
         auto limit_descendant_count = gArgs.GetArg("-limitdescendantcount", DEFAULT_DESCENDANT_LIMIT);

--- a/src/memusage.h
+++ b/src/memusage.h
@@ -153,8 +153,8 @@ private:
     void* ptr;
 };
 
-template<typename X, typename Y>
-static inline size_t DynamicUsage(const std::unordered_set<X, Y>& s)
+template<typename X, typename Y, typename Z>
+static inline size_t DynamicUsage(const std::unordered_set<X, Y, Z>& s)
 {
     return MallocUsage(sizeof(unordered_node<X>)) * s.size() + MallocUsage(sizeof(void*) * s.bucket_count());
 }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -386,10 +386,11 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
             continue;
         }
 
-        CTxMemPool::setEntries ancestors;
+        std::vector<CTxMemPool::txiter> vec_ancestors;
         uint64_t nNoLimit = std::numeric_limits<uint64_t>::max();
         std::string dummy;
-        mempool.CalculateMemPoolAncestors(*iter, ancestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy, false);
+        mempool.CalculateMemPoolAncestors(*iter, vec_ancestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy, false);
+        CTxMemPool::setEntries ancestors{vec_ancestors.begin(), vec_ancestors.end()};
 
         onlyUnconfirmed(ancestors);
         ancestors.insert(iter);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -236,9 +236,13 @@ int BlockAssembler::UpdatePackagesForAdded(const SortedIterable& alreadyAdded,
         indexed_modified_transaction_set &mapModifiedTx)
 {
     int nDescendantsUpdated = 0;
+    CTxMemPool::vecEntries descendants;
     for (CTxMemPool::txiter it : alreadyAdded) {
-        CTxMemPool::setEntries descendants;
-        mempool.CalculateDescendants(it, descendants);
+        descendants.clear();
+        // can't use external epoch to loop because we want to update
+        // all descendants
+        // No need to add self (it) because we would filter it from the loop
+        mempool.CalculateDescendantsVec(it, descendants);
         // Insert all descendants (not yet in block) into the modified set
         for (CTxMemPool::txiter desc : descendants) {
             if (std::binary_search(alreadyAdded.cbegin(), alreadyAdded.cend(), desc, CTxMemPool::CompareIteratorByHash()))

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -223,9 +223,9 @@ void BlockAssembler::AddToBlock(CTxMemPool::txiter iter)
     }
 }
 
-template<typename SortedIterable>
-int BlockAssembler::UpdatePackagesForAdded(const SortedIterable& alreadyAdded,
-        indexed_modified_transaction_set &mapModifiedTx)
+template<typename Iterable, typename BinPred>
+int BlockAssembler::UpdatePackagesForAdded(const Iterable& alreadyAdded,
+        BinPred&& predicate, indexed_modified_transaction_set &mapModifiedTx)
 {
     int nDescendantsUpdated = 0;
     CTxMemPool::vecEntries descendants;
@@ -237,8 +237,7 @@ int BlockAssembler::UpdatePackagesForAdded(const SortedIterable& alreadyAdded,
         mempool.CalculateDescendantsVec(it, descendants);
         // Insert all descendants (not yet in block) into the modified set
         for (CTxMemPool::txiter desc : descendants) {
-            if (std::binary_search(alreadyAdded.cbegin(), alreadyAdded.cend(), desc, CTxMemPool::CompareIteratorByHash()))
-                continue;
+            if (predicate(desc)) continue;
             ++nDescendantsUpdated;
             modtxiter mit = mapModifiedTx.find(desc);
             if (mit == mapModifiedTx.end()) {
@@ -299,7 +298,7 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
 
     // Start by adding all descendants of previously added txs to mapModifiedTx
     // and modifying them for their already included ancestors
-    UpdatePackagesForAdded(inBlock, mapModifiedTx);
+    UpdatePackagesForAdded(inBlock, [&](CTxMemPool::txiter t){return inBlock.count(t);}, mapModifiedTx);
 
     CTxMemPool::indexed_transaction_set::index<ancestor_score>::type::iterator mi = mempool.mapTx.get<ancestor_score>().begin();
     CTxMemPool::txiter iter;
@@ -417,7 +416,11 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
         // Sort before passing in
         // TODO: unclear if hash order is needed or if txiter would suffice
         std::sort(ancestors.begin(), ancestors.end(), CTxMemPool::CompareIteratorByHash());
-        nDescendantsUpdated += UpdatePackagesForAdded(ancestors, mapModifiedTx);
+
+        nDescendantsUpdated += UpdatePackagesForAdded(ancestors,
+                [&](CTxMemPool::txiter t){
+                    return std::binary_search(ancestors.cbegin(), ancestors.cend(), t, CTxMemPool::CompareIteratorByHash());
+                }, mapModifiedTx);
     }
 }
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -234,6 +234,7 @@ int BlockAssembler::UpdatePackagesForAdded(const Iterable& alreadyAdded,
         // can't use external epoch to loop because we want to update
         // all descendants
         // No need to add self (it) because we would filter it from the loop
+        mempool.GetFreshEpoch();
         mempool.CalculateDescendantsVec(it, descendants);
         // Insert all descendants (not yet in block) into the modified set
         for (CTxMemPool::txiter desc : descendants) {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -173,17 +173,18 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     return std::move(pblocktemplate);
 }
 
-void BlockAssembler::onlyUnconfirmed(CTxMemPool::setEntries& testSet)
+void BlockAssembler::onlyUnconfirmed(CTxMemPool::vecEntries& testSet)
 {
-    for (CTxMemPool::setEntries::iterator iit = testSet.begin(); iit != testSet.end(); ) {
-        // Only test txs not already in the block
-        if (inBlock.count(*iit)) {
-            testSet.erase(iit++);
-        }
-        else {
-            iit++;
-        }
+    size_t max_element = testSet.size(), i = 0;
+    while (i < max_element) {
+        bool not_in_block = !inBlock.count(testSet[i]);
+        // if !not_in_block, set testSet[i] to testSet[max_element-1]
+        max_element -= !not_in_block;
+        testSet[i] = testSet[!not_in_block*max_element + not_in_block*i];
+        i += not_in_block;
     }
+    // drop erased elements
+    testSet.resize(max_element);
 }
 
 bool BlockAssembler::TestPackage(uint64_t packageSize, int64_t packageSigOpsCost) const
@@ -200,7 +201,7 @@ bool BlockAssembler::TestPackage(uint64_t packageSize, int64_t packageSigOpsCost
 // - transaction finality (locktime)
 // - premature witness (in case segwit transactions are added to mempool before
 //   segwit activation)
-bool BlockAssembler::TestPackageTransactions(const CTxMemPool::setEntries& package)
+bool BlockAssembler::TestPackageTransactions(const CTxMemPool::vecEntries& package)
 {
     for (CTxMemPool::txiter it : package) {
         if (!IsFinalTx(it->GetTx(), nHeight, nLockTimeCutoff))
@@ -230,7 +231,8 @@ void BlockAssembler::AddToBlock(CTxMemPool::txiter iter)
     }
 }
 
-int BlockAssembler::UpdatePackagesForAdded(const CTxMemPool::setEntries& alreadyAdded,
+template<typename SortedIterable>
+int BlockAssembler::UpdatePackagesForAdded(const SortedIterable& alreadyAdded,
         indexed_modified_transaction_set &mapModifiedTx)
 {
     int nDescendantsUpdated = 0;
@@ -239,7 +241,7 @@ int BlockAssembler::UpdatePackagesForAdded(const CTxMemPool::setEntries& already
         mempool.CalculateDescendants(it, descendants);
         // Insert all descendants (not yet in block) into the modified set
         for (CTxMemPool::txiter desc : descendants) {
-            if (alreadyAdded.count(desc))
+            if (std::binary_search(alreadyAdded.cbegin(), alreadyAdded.cend(), desc, CTxMemPool::CompareIteratorByHash()))
                 continue;
             ++nDescendantsUpdated;
             modtxiter mit = mapModifiedTx.find(desc);
@@ -272,15 +274,13 @@ bool BlockAssembler::SkipMapTxEntry(CTxMemPool::txiter it, indexed_modified_tran
     return mapModifiedTx.count(it) || inBlock.count(it) || failedTx.count(it);
 }
 
-void BlockAssembler::SortForBlock(const CTxMemPool::setEntries& package, std::vector<CTxMemPool::txiter>& sortedEntries)
+void BlockAssembler::SortForBlock(CTxMemPool::vecEntries& unsorted_entries)
 {
     // Sort package by ancestor count
     // If a transaction A depends on transaction B, then A's ancestor count
     // must be greater than B's.  So this is sufficient to validly order the
     // transactions for block inclusion.
-    sortedEntries.clear();
-    sortedEntries.insert(sortedEntries.begin(), package.begin(), package.end());
-    std::sort(sortedEntries.begin(), sortedEntries.end(), CompareTxIterByAncestorCount());
+    std::sort(unsorted_entries.begin(), unsorted_entries.end(), CompareTxIterByAncestorCount());
 }
 
 // This transaction selection algorithm orders the mempool based
@@ -386,14 +386,13 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
             continue;
         }
 
-        std::vector<CTxMemPool::txiter> vec_ancestors;
+        CTxMemPool::vecEntries ancestors;
         uint64_t nNoLimit = std::numeric_limits<uint64_t>::max();
         std::string dummy;
-        mempool.CalculateMemPoolAncestors(*iter, vec_ancestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy, false);
-        CTxMemPool::setEntries ancestors{vec_ancestors.begin(), vec_ancestors.end()};
+        mempool.CalculateMemPoolAncestors(*iter, ancestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy, false);
 
         onlyUnconfirmed(ancestors);
-        ancestors.insert(iter);
+        ancestors.push_back(iter);
 
         // Test if all tx's are Final
         if (!TestPackageTransactions(ancestors)) {
@@ -408,18 +407,20 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
         nConsecutiveFailed = 0;
 
         // Package can be added. Sort the entries in a valid order.
-        std::vector<CTxMemPool::txiter> sortedEntries;
-        SortForBlock(ancestors, sortedEntries);
+        SortForBlock(ancestors);
 
-        for (size_t i=0; i<sortedEntries.size(); ++i) {
-            AddToBlock(sortedEntries[i]);
+        for (CTxMemPool::txiter ancestor : ancestors) {
+            AddToBlock(ancestor);
             // Erase from the modified set, if present
-            mapModifiedTx.erase(sortedEntries[i]);
+            mapModifiedTx.erase(ancestor);
         }
 
         ++nPackagesSelected;
 
         // Update transactions that depend on each of these
+        // Sort before passing in
+        // TODO: unclear if hash order is needed or if txiter would suffice
+        std::sort(ancestors.begin(), ancestors.end(), CTxMemPool::CompareIteratorByHash());
         nDescendantsUpdated += UpdatePackagesForAdded(ancestors, mapModifiedTx);
     }
 }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -234,8 +234,10 @@ int BlockAssembler::UpdatePackagesForAdded(const Iterable& alreadyAdded,
         // can't use external epoch to loop because we want to update
         // all descendants
         // No need to add self (it) because we would filter it from the loop
-        mempool.GetFreshEpoch();
-        mempool.CalculateDescendantsVec(it, descendants);
+        {
+            const auto epoch = mempool.GetFreshEpoch();
+            mempool.CalculateDescendantsVec(it, descendants);
+        } // release epoch guard just in case predicate uses epochs (it doesn't)
         // Insert all descendants (not yet in block) into the modified set
         for (CTxMemPool::txiter desc : descendants) {
             if (predicate(desc)) continue;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -175,16 +175,8 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
 
 void BlockAssembler::onlyUnconfirmed(CTxMemPool::vecEntries& testSet)
 {
-    size_t max_element = testSet.size(), i = 0;
-    while (i < max_element) {
-        bool not_in_block = !inBlock.count(testSet[i]);
-        // if !not_in_block, set testSet[i] to testSet[max_element-1]
-        max_element -= !not_in_block;
-        testSet[i] = testSet[!not_in_block*max_element + not_in_block*i];
-        i += not_in_block;
-    }
-    // drop erased elements
-    testSet.resize(max_element);
+    testSet.erase(std::remove_if(testSet.begin(), testSet.end(),
+                [this](CTxMemPool::txiter t){return inBlock.count(t);}), testSet.end());
 }
 
 bool BlockAssembler::TestPackage(uint64_t packageSize, int64_t packageSigOpsCost) const

--- a/src/miner.h
+++ b/src/miner.h
@@ -179,23 +179,24 @@ private:
 
     // helper functions for addPackageTxs()
     /** Remove confirmed (inBlock) entries from given set */
-    void onlyUnconfirmed(CTxMemPool::setEntries& testSet);
+    void onlyUnconfirmed(CTxMemPool::vecEntries& testSet);
     /** Test if a new package would "fit" in the block */
     bool TestPackage(uint64_t packageSize, int64_t packageSigOpsCost) const;
     /** Perform checks on each transaction in a package:
       * locktime, premature-witness, serialized size (if necessary)
       * These checks should always succeed, and they're here
       * only as an extra check in case of suboptimal node configuration */
-    bool TestPackageTransactions(const CTxMemPool::setEntries& package);
+    bool TestPackageTransactions(const CTxMemPool::vecEntries& package);
     /** Return true if given transaction from mapTx has already been evaluated,
       * or if the transaction's cached data in mapTx is incorrect. */
     bool SkipMapTxEntry(CTxMemPool::txiter it, indexed_modified_transaction_set &mapModifiedTx, CTxMemPool::setEntries &failedTx) EXCLUSIVE_LOCKS_REQUIRED(mempool.cs);
     /** Sort the package in an order that is valid to appear in a block */
-    void SortForBlock(const CTxMemPool::setEntries& package, std::vector<CTxMemPool::txiter>& sortedEntries);
+    void SortForBlock(CTxMemPool::vecEntries& package);
     /** Add descendants of given transactions to mapModifiedTx with ancestor
       * state updated assuming given transactions are inBlock. Returns number
       * of updated descendants. */
-    int UpdatePackagesForAdded(const CTxMemPool::setEntries& alreadyAdded, indexed_modified_transaction_set &mapModifiedTx) EXCLUSIVE_LOCKS_REQUIRED(mempool.cs);
+    template<typename SortedIterable>
+    int UpdatePackagesForAdded(const SortedIterable& alreadyAdded, indexed_modified_transaction_set &mapModifiedTx) EXCLUSIVE_LOCKS_REQUIRED(mempool.cs);
 };
 
 /** Modify the extranonce in a block */

--- a/src/miner.h
+++ b/src/miner.h
@@ -194,9 +194,9 @@ private:
     void SortForBlock(CTxMemPool::vecEntries& package);
     /** Add descendants of given transactions to mapModifiedTx with ancestor
       * state updated assuming given transactions are inBlock. Returns number
-      * of updated descendants. */
-    template<typename SortedIterable>
-    int UpdatePackagesForAdded(const SortedIterable& alreadyAdded, indexed_modified_transaction_set &mapModifiedTx) EXCLUSIVE_LOCKS_REQUIRED(mempool.cs);
+      * of updated descendants. Param predicate tests if a child is in alreadyAdded.*/
+    template<typename Iterable, typename BinPred>
+    int UpdatePackagesForAdded(const Iterable& alreadyAdded, BinPred&& predicate, indexed_modified_transaction_set &mapModifiedTx) EXCLUSIVE_LOCKS_REQUIRED(mempool.cs);
 };
 
 /** Modify the extranonce in a block */

--- a/src/policy/rbf.cpp
+++ b/src/policy/rbf.cpp
@@ -9,7 +9,7 @@ RBFTransactionState IsRBFOptIn(const CTransaction& tx, const CTxMemPool& pool)
 {
     AssertLockHeld(pool.cs);
 
-    CTxMemPool::setEntries setAncestors;
+    CTxMemPool::vecEntries ancestors;
 
     // First check the transaction itself.
     if (SignalsOptInRBF(tx)) {
@@ -27,9 +27,9 @@ RBFTransactionState IsRBFOptIn(const CTransaction& tx, const CTxMemPool& pool)
     uint64_t noLimit = std::numeric_limits<uint64_t>::max();
     std::string dummy;
     CTxMemPoolEntry entry = *pool.mapTx.find(tx.GetHash());
-    pool.CalculateMemPoolAncestors(entry, setAncestors, noLimit, noLimit, noLimit, noLimit, dummy, false);
+    pool.CalculateMemPoolAncestors(entry, ancestors, noLimit, noLimit, noLimit, noLimit, dummy, false);
 
-    for (CTxMemPool::txiter it : setAncestors) {
+    for (CTxMemPool::txiter it : ancestors) {
         if (SignalsOptInRBF(it->GetTx())) {
             return RBFTransactionState::REPLACEABLE_BIP125;
         }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -443,9 +443,9 @@ static void entryToJSON(const CTxMemPool& pool, UniValue& info, const CTxMemPool
 
     UniValue spent(UniValue::VARR);
     const CTxMemPool::txiter& it = pool.mapTx.find(tx.GetHash());
-    const CTxMemPool::setEntries& setChildren = pool.GetMemPoolChildren(it);
-    for (CTxMemPool::txiter childiter : setChildren) {
-        spent.push_back(childiter->GetTx().GetHash().ToString());
+    const CTxMemPoolEntry::relatives& setChildren = it->GetMemPoolChildrenConst();
+    for (const CTxMemPoolEntry& child: setChildren) {
+        spent.push_back(child.GetTx().GetHash().ToString());
     }
 
     info.pushKV("spentby", spent);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -564,21 +564,21 @@ static UniValue getmempoolancestors(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction not in mempool");
     }
 
-    CTxMemPool::vecEntries setAncestors;
+    CTxMemPool::vecEntries ancestors;
     uint64_t noLimit = std::numeric_limits<uint64_t>::max();
     std::string dummy;
-    mempool.CalculateMemPoolAncestors(*it, setAncestors, noLimit, noLimit, noLimit, noLimit, dummy, false);
+    mempool.CalculateMemPoolAncestors(*it, ancestors, noLimit, noLimit, noLimit, noLimit, dummy, false);
 
     if (!fVerbose) {
         UniValue o(UniValue::VARR);
-        for (CTxMemPool::txiter ancestorIt : setAncestors) {
+        for (CTxMemPool::txiter ancestorIt : ancestors) {
             o.push_back(ancestorIt->GetTx().GetHash().ToString());
         }
 
         return o;
     } else {
         UniValue o(UniValue::VOBJ);
-        for (CTxMemPool::txiter ancestorIt : setAncestors) {
+        for (CTxMemPool::txiter ancestorIt : ancestors) {
             const CTxMemPoolEntry &e = *ancestorIt;
             const uint256& _hash = e.GetTx().GetHash();
             UniValue info(UniValue::VOBJ);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -631,6 +631,7 @@ static UniValue getmempooldescendants(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction not in mempool");
     }
 
+    mempool.GetFreshEpoch();
     CTxMemPool::vecEntries setDescendants;
     mempool.CalculateDescendantsVec(it, setDescendants);
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -631,10 +631,8 @@ static UniValue getmempooldescendants(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction not in mempool");
     }
 
-    CTxMemPool::setEntries setDescendants;
-    mempool.CalculateDescendants(it, setDescendants);
-    // CTxMemPool::CalculateDescendants will include the given tx
-    setDescendants.erase(it);
+    CTxMemPool::vecEntries setDescendants;
+    mempool.CalculateDescendantsVec(it, setDescendants);
 
     if (!fVerbose) {
         UniValue o(UniValue::VARR);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -564,7 +564,7 @@ static UniValue getmempoolancestors(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction not in mempool");
     }
 
-    CTxMemPool::setEntries setAncestors;
+    CTxMemPool::vecEntries setAncestors;
     uint64_t noLimit = std::numeric_limits<uint64_t>::max();
     std::string dummy;
     mempool.CalculateMemPoolAncestors(*it, setAncestors, noLimit, noLimit, noLimit, noLimit, dummy, false);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -631,9 +631,11 @@ static UniValue getmempooldescendants(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction not in mempool");
     }
 
-    mempool.GetFreshEpoch();
     CTxMemPool::vecEntries setDescendants;
-    mempool.CalculateDescendantsVec(it, setDescendants);
+    {
+        const auto epoch = mempool.GetFreshEpoch();
+        mempool.CalculateDescendantsVec(it, setDescendants);
+    } // release epoch guard because entryToJSON below calls IsRBFOptIn
 
     if (!fVerbose) {
         UniValue o(UniValue::VARR);

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -539,7 +539,7 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
         pool.addUnchecked(entry.Fee(1000LL).FromTx(tx5));
     pool.addUnchecked(entry.Fee(9000LL).FromTx(tx7));
 
-    pool.TrimToSize(pool.DynamicMemoryUsage() / 2); // should maximize mempool size by only removing 5/7
+    pool.TrimToSize(pool.DynamicMemoryUsage()*55 / 100); // should maximize mempool size by only removing 5/7
     BOOST_CHECK(pool.exists(tx4.GetHash()));
     BOOST_CHECK(!pool.exists(tx5.GetHash()));
     BOOST_CHECK(pool.exists(tx6.GetHash()));

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -539,7 +539,7 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
         pool.addUnchecked(entry.Fee(1000LL).FromTx(tx5));
     pool.addUnchecked(entry.Fee(9000LL).FromTx(tx7));
 
-    pool.TrimToSize(pool.DynamicMemoryUsage()*55 / 100); // should maximize mempool size by only removing 5/7
+    pool.TrimToSize(pool.DynamicMemoryUsage()*60/100); // should maximize mempool size by only removing 5/7
     BOOST_CHECK(pool.exists(tx4.GetHash()));
     BOOST_CHECK(!pool.exists(tx5.GetHash()));
     BOOST_CHECK(pool.exists(tx6.GetHash()));

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -57,7 +57,7 @@ size_t CTxMemPoolEntry::GetTxSize() const
 // Assumes that setMemPoolChildren is correct for the given tx and all
 // descendants.
 //
-void CTxMemPool::UpdateForDescendants(txiter update_it, cacheMap& cache, const std::set<uint256>& exclude) {
+void CTxMemPool::UpdateForDescendants(txiter update_it, cacheMap& cache, const std::unordered_set<uint256, SaltedTxidHasher>& exclude) {
     const auto epoch = GetFreshEpoch();
     int64_t modify_size = 0;
     CAmount modify_fee = 0;
@@ -127,7 +127,7 @@ void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<uint256> &vHashes
 
     // Use a set for lookups into vHashesToUpdate (these entries are already
     // accounted for in the state of their ancestors)
-    std::set<uint256> setAlreadyIncluded(vHashesToUpdate.begin(), vHashesToUpdate.end());
+    std::unordered_set<uint256, SaltedTxidHasher> setAlreadyIncluded(vHashesToUpdate.begin(), vHashesToUpdate.end());
 
     // Iterate in reverse, so that whenever we are looking at a transaction
     // we are sure that all in-mempool descendants have already been processed.

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -450,7 +450,8 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
 // Also assumes that if an entry is in setDescendants already, then all
 // in-mempool descendants of it are already in setDescendants as well, so that we
 // can save time by not iterating over those entries.
-void CTxMemPool::CalculateDescendants(txiter it, setEntries& setDescendants, std::vector<txiter>& stack, const uint64_t epoch, const uint8_t limit) const {
+void CTxMemPool::CalculateDescendants(txiter it, setEntries& setDescendants, std::vector<txiter>& stack, const uint64_t epoch, const uint8_t limit) const
+{
         for (txiter childiter : GetMemPoolChildren(it)) {
             if (childiter->already_touched(epoch)) continue;
             if (!setDescendants.insert(childiter).second) continue;
@@ -458,17 +459,22 @@ void CTxMemPool::CalculateDescendants(txiter it, setEntries& setDescendants, std
             else stack.push_back(childiter);
         }
 }
+
 void CTxMemPool::CalculateDescendants(txiter entryit, setEntries& setDescendants) const
+{
+    CalculateDescendants(entryit, setDescendants, GetFreshEpoch());
+}
+
+void CTxMemPool::CalculateDescendants(txiter entryit, setEntries& setDescendants, const uint64_t cached_epoch) const
 {
     if (!setDescendants.insert(entryit).second) return;
     // Traverse down the children of entry, only adding children that are not
     // accounted for in setDescendants already (because those children have either
     // already been walked, or will be walked in this iteration).
-    const uint64_t epoch = GetFreshEpoch();
     txiter it = entryit;
     std::vector<txiter> stack;
     do {
-        CalculateDescendants(it, setDescendants, stack, epoch);
+        CalculateDescendants(it, setDescendants, stack, cached_epoch);
     } while (!stack.empty() && (it = stack.back(), stack.pop_back(), true));
 
 }
@@ -496,8 +502,9 @@ void CTxMemPool::removeRecursive(const CTransaction &origTx, MemPoolRemovalReaso
             }
         }
         setEntries setAllRemoves;
+        const uint64_t epoch = GetFreshEpoch();
         for (txiter it : txToRemove) {
-            CalculateDescendants(it, setAllRemoves);
+            CalculateDescendants(it, setAllRemoves, epoch);
         }
 
         RemoveStaged(setAllRemoves, false, reason);
@@ -534,8 +541,9 @@ void CTxMemPool::removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMem
         }
     }
     setEntries setAllRemoves;
+    const uint64_t epoch = GetFreshEpoch();
     for (txiter it : txToRemove) {
-        CalculateDescendants(it, setAllRemoves);
+        CalculateDescendants(it, setAllRemoves, epoch);
     }
     RemoveStaged(setAllRemoves, false, MemPoolRemovalReason::REORG);
 }
@@ -946,8 +954,9 @@ int CTxMemPool::Expire(std::chrono::seconds time)
         it++;
     }
     setEntries stage;
+    const uint64_t epoch = GetFreshEpoch();
     for (txiter removeit : toremove) {
-        CalculateDescendants(removeit, stage);
+        CalculateDescendants(removeit, stage, epoch);
     }
     RemoveStaged(stage, false, MemPoolRemovalReason::EXPIRY);
     return stage.size();

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -22,7 +22,7 @@ CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef& _tx, const CAmount& _nFe
                                  int64_t _nTime, unsigned int _entryHeight,
                                  bool _spendsCoinbase, int64_t _sigOpsCost, LockPoints lp)
     : tx(_tx), nFee(_nFee), nTxWeight(GetTransactionWeight(*tx)), nUsageSize(RecursiveDynamicUsage(tx)), nTime(_nTime), entryHeight(_entryHeight),
-    spendsCoinbase(_spendsCoinbase), sigOpCost(_sigOpsCost), lockPoints(lp)
+    spendsCoinbase(_spendsCoinbase), sigOpCost(_sigOpsCost), lockPoints(lp), m_epoch(0)
 {
     nCountWithDescendants = 1;
     nSizeWithDescendants = GetTxSize();
@@ -1097,6 +1097,11 @@ void CTxMemPool::SetIsLoaded(bool loaded)
 {
     LOCK(cs);
     m_is_loaded = loaded;
+}
+
+uint64_t CTxMemPool::GetFreshEpoch() const
+{
+    return ++m_epoch;
 }
 
 SaltedTxidHasher::SaltedTxidHasher() : k0(GetRand(std::numeric_limits<uint64_t>::max())), k1(GetRand(std::numeric_limits<uint64_t>::max())) {}

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -462,34 +462,8 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
 // Also assumes that if an entry is in setDescendants already, then all
 // in-mempool descendants of it are already in setDescendants as well, so that we
 // can save time by not iterating over those entries.
-void CTxMemPool::CalculateDescendants(txiter it, setEntries& setDescendants, std::vector<txiter>& stack, const uint64_t epoch, const uint8_t limit) const
-{
-        for (txiter childiter : GetMemPoolChildren(it)) {
-            if (childiter->already_touched(epoch)) continue;
-            if (!setDescendants.insert(childiter).second) continue;
-            if (limit > 0) CalculateDescendants(childiter, setDescendants, stack, epoch, limit-1);
-            else stack.push_back(childiter);
-        }
-}
-
-void CTxMemPool::CalculateDescendants(txiter entryit, setEntries& setDescendants) const
-{
-    CalculateDescendants(entryit, setDescendants, GetFreshEpoch());
-}
-
-void CTxMemPool::CalculateDescendants(txiter entryit, setEntries& setDescendants, const uint64_t cached_epoch) const
-{
-    if (!setDescendants.insert(entryit).second) return;
-    // Traverse down the children of entry, only adding children that are not
-    // accounted for in setDescendants already (because those children have either
-    // already been walked, or will be walked in this iteration).
-    txiter it = entryit;
-    std::vector<txiter> stack;
-    do {
-        CalculateDescendants(it, setDescendants, stack, cached_epoch);
-    } while (!stack.empty() && (it = stack.back(), stack.pop_back(), true));
-
-}
+//
+// Note: it does not get inserted into the vector
 
 void CTxMemPool::CalculateDescendantsVec(txiter it, std::vector<txiter>& descendants, std::vector<txiter>& stack, const uint64_t epoch, const uint8_t limit) const
 {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -269,9 +269,7 @@ void CTxMemPool::UpdateChildrenForRemoval(txiter it)
     }
 }
 
-template <typename T>
-void CTxMemPool::UpdateForRemoveFromMempoolImpl(const T &entriesToRemove, bool updateDescendants)
-{
+void CTxMemPool::UpdateForRemoveFromMempool(const vecEntries &entriesToRemove, bool updateDescendants) {
     // For each entry, walk back all ancestors and decrement size associated with this
     // transaction
     const uint64_t nNoLimit = std::numeric_limits<uint64_t>::max();
@@ -325,13 +323,6 @@ void CTxMemPool::UpdateForRemoveFromMempoolImpl(const T &entriesToRemove, bool u
     for (txiter removeIt : entriesToRemove) {
         UpdateChildrenForRemoval(removeIt);
     }
-}
-void CTxMemPool::UpdateForRemoveFromMempool(const vecEntries &entriesToRemove, bool updateDescendants) {
-    UpdateForRemoveFromMempoolImpl(entriesToRemove, updateDescendants);
-}
-
-void CTxMemPool::UpdateForRemoveFromMempool(const setEntries &entriesToRemove, bool updateDescendants) {
-    UpdateForRemoveFromMempoolImpl(entriesToRemove, updateDescendants);
 }
 
 void CTxMemPoolEntry::UpdateDescendantState(int64_t modifySize, CAmount modifyFee, int64_t modifyCount)
@@ -965,20 +956,12 @@ size_t CTxMemPool::DynamicMemoryUsage() const {
     return memusage::MallocUsage(sizeof(CTxMemPoolEntry) + 12 * sizeof(void*)) * mapTx.size() + memusage::DynamicUsage(mapNextTx) + memusage::DynamicUsage(mapDeltas) + memusage::DynamicUsage(mapLinks) + memusage::DynamicUsage(vTxHashes) + cachedInnerUsage;
 }
 
-template<typename T>
-void CTxMemPool::RemoveStagedImpl(T &stage, bool updateDescendants, MemPoolRemovalReason reason) {
+void CTxMemPool::RemoveStaged(vecEntries &stage, bool updateDescendants, MemPoolRemovalReason reason) {
     AssertLockHeld(cs);
     UpdateForRemoveFromMempool(stage, updateDescendants);
     for (txiter it : stage) {
         removeUnchecked(it, reason);
     }
-}
-
-void CTxMemPool::RemoveStaged(vecEntries &stage, bool updateDescendants, MemPoolRemovalReason reason) {
-    RemoveStagedImpl(stage, updateDescendants, reason);
-}
-void CTxMemPool::RemoveStaged(setEntries &stage, bool updateDescendants, MemPoolRemovalReason reason) {
-    RemoveStagedImpl(stage, updateDescendants, reason);
 }
 
 int CTxMemPool::Expire(std::chrono::seconds time)

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -58,25 +58,34 @@ size_t CTxMemPoolEntry::GetTxSize() const
 // descendants.
 void CTxMemPool::UpdateForDescendants(txiter updateIt, cacheMap &cachedDescendants, const std::set<uint256> &setExclude)
 {
-    setEntries stageEntries, setAllDescendants;
-    stageEntries = GetMemPoolChildren(updateIt);
+    auto& direct_children = GetMemPoolChildren(updateIt);
+    // Our children are natrually uniqueu
+    std::vector<txiter> all_descendants{direct_children.cbegin(), direct_children.cend()};
+    std::vector<txiter> stack;
+    uint64_t epoch = GetFreshEpoch();
 
-    while (!stageEntries.empty()) {
-        const txiter cit = *stageEntries.begin();
-        setAllDescendants.insert(cit);
-        stageEntries.erase(cit);
+    auto children_it = direct_children.begin();
+    while (children_it != direct_children.end() || !stack.empty()) {
+        // Either pop the stack or read from the direct_children
+        bool have_direct_children = children_it != direct_children.end();
+        const txiter cit =  have_direct_children ? *(children_it++) : stack.back();
+        if (!have_direct_children) stack.pop_back();
+
         const setEntries &setChildren = GetMemPoolChildren(cit);
         for (txiter childEntry : setChildren) {
+            if (childEntry->already_touched(epoch)) continue;
             cacheMap::iterator cacheIt = cachedDescendants.find(childEntry);
             if (cacheIt != cachedDescendants.end()) {
                 // We've already calculated this one, just add the entries for this set
                 // but don't traverse again.
                 for (txiter cacheEntry : cacheIt->second) {
-                    setAllDescendants.insert(cacheEntry);
+                    if (cacheEntry->already_touched(epoch)) continue;
+                    all_descendants.push_back(cacheEntry);
                 }
-            } else if (!setAllDescendants.count(childEntry)) {
+            } else {
                 // Schedule for later processing
-                stageEntries.insert(childEntry);
+                stack.push_back(childEntry);
+                all_descendants.push_back(childEntry);
             }
         }
     }
@@ -85,7 +94,7 @@ void CTxMemPool::UpdateForDescendants(txiter updateIt, cacheMap &cachedDescendan
     int64_t modifySize = 0;
     CAmount modifyFee = 0;
     int64_t modifyCount = 0;
-    for (txiter cit : setAllDescendants) {
+    for (txiter cit : all_descendants) {
         if (!setExclude.count(cit->GetTx().GetHash())) {
             modifySize += cit->GetTxSize();
             modifyFee += cit->GetModifiedFee();

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -374,10 +374,12 @@ void CTxMemPool::addUnchecked(const CTxMemPoolEntry &entry, setEntries &setAnces
     cachedInnerUsage += entry.DynamicMemoryUsage();
 
     const CTransaction& tx = newit->GetTx();
-    std::set<uint256> setParentTransactions;
+    uint64_t epoch = GetFreshEpoch();
     for (unsigned int i = 0; i < tx.vin.size(); i++) {
         mapNextTx.insert(std::make_pair(&tx.vin[i].prevout, &tx));
-        setParentTransactions.insert(tx.vin[i].prevout.hash);
+        // Update ancestors with information about this tx
+        auto maybe_it = GetIter(tx.vin[i].prevout.hash);
+        if (maybe_it && !(*maybe_it)->already_touched(epoch)) UpdateParent(newit, *maybe_it, true);
     }
     // Don't bother worrying about child transactions of this one.
     // Normal case of a new transaction arriving is that there can't be any
@@ -387,9 +389,6 @@ void CTxMemPool::addUnchecked(const CTxMemPoolEntry &entry, setEntries &setAnces
     // to clean up the mess we're leaving here.
 
     // Update ancestors with information about this tx
-    for (const auto& pit : GetIterSet(setParentTransactions)) {
-            UpdateParent(newit, pit, true);
-    }
     UpdateAncestorsOf(true, newit, setAncestors);
     UpdateEntryForAncestors(newit, setAncestors);
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -277,13 +277,12 @@ void CTxMemPool::UpdateForRemoveFromMempool(const setEntries &entriesToRemove, b
         // we need to preserve until we're finished with all operations that
         // need to traverse the mempool).
         for (txiter removeIt : entriesToRemove) {
-            setEntries setDescendants;
-            CalculateDescendants(removeIt, setDescendants);
-            setDescendants.erase(removeIt); // don't update state for self
+            std::vector<txiter> descendants;
+            CalculateDescendantsVec(removeIt, descendants);
             int64_t modifySize = -((int64_t)removeIt->GetTxSize());
             CAmount modifyFee = -removeIt->GetModifiedFee();
             int modifySigOps = -removeIt->GetSigOpCost();
-            for (txiter dit : setDescendants) {
+            for (txiter dit : descendants) {
                 mapTx.modify(dit, update_ancestor_state(modifySize, modifyFee, -1, modifySigOps));
             }
         }
@@ -477,6 +476,32 @@ void CTxMemPool::CalculateDescendants(txiter entryit, setEntries& setDescendants
         CalculateDescendants(it, setDescendants, stack, cached_epoch);
     } while (!stack.empty() && (it = stack.back(), stack.pop_back(), true));
 
+}
+
+void CTxMemPool::CalculateDescendantsVec(txiter it, std::vector<txiter>& descendants, std::vector<txiter>& stack, const uint64_t epoch, const uint8_t limit) const
+{
+    for (txiter childiter : GetMemPoolChildren(it)) {
+        if (childiter->already_touched(epoch)) continue;
+        descendants.push_back(childiter);
+        if (limit > 0) CalculateDescendantsVec(childiter, descendants, stack, epoch, limit-1);
+        else stack.push_back(childiter);
+    }
+}
+
+void CTxMemPool::CalculateDescendantsVec(txiter entryit, std::vector<txiter>& descendants) const
+{
+    CalculateDescendantsVec(entryit, descendants, GetFreshEpoch());
+}
+
+void CTxMemPool::CalculateDescendantsVec(txiter entryit, std::vector<txiter>& descendants, const uint64_t cached_epoch) const
+{
+    // Traverse down the children of entry, only adding children that are not marked as visited by
+    // the epoch
+    txiter it = entryit;
+    std::vector<txiter> stack;
+    do {
+        CalculateDescendantsVec(it, descendants, stack, cached_epoch);
+    } while (!stack.empty() && (it = stack.back(), stack.pop_back(), true));
 }
 
 void CTxMemPool::removeRecursive(const CTransaction &origTx, MemPoolRemovalReason reason)
@@ -853,9 +878,8 @@ void CTxMemPool::PrioritiseTransaction(const uint256& hash, const CAmount& nFeeD
                 mapTx.modify(ancestorIt, update_descendant_state(0, nFeeDelta, 0));
             }
             // Now update all descendants' modified fees with ancestors
-            setEntries setDescendants;
-            CalculateDescendants(it, setDescendants);
-            setDescendants.erase(it);
+            std::vector<txiter> setDescendants;
+            CalculateDescendantsVec(it, setDescendants);
             for (txiter descendantIt : setDescendants) {
                 mapTx.modify(descendantIt, update_ancestor_state(0, nFeeDelta, 0, 0));
             }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -463,26 +463,21 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
 // can save time by not iterating over those entries.
 //
 // Note: it does not get inserted into the vector
-
-void CTxMemPool::CalculateDescendantsVec(txiter it, vecEntries& descendants, vecEntries& stack, const uint8_t limit) const
-{
-    for (txiter childiter : GetMemPoolChildren(it)) {
-        if (already_touched(childiter)) continue;
-        descendants.push_back(childiter);
-        if (limit > 0) CalculateDescendantsVec(childiter, descendants, stack, limit-1);
-        else stack.push_back(childiter);
-    }
-}
-
 void CTxMemPool::CalculateDescendantsVec(txiter entryit, vecEntries& descendants) const
 {
     // Traverse down the children of entry, only adding children that are not marked as visited by
     // the epoch
     txiter it = entryit;
-    vecEntries stack;
-    do {
-        CalculateDescendantsVec(it, descendants, stack);
-    } while (!stack.empty() && (it = stack.back(), stack.pop_back(), true));
+    size_t idx = descendants.size();
+    while (true) {
+        for (const auto& childiter : GetMemPoolChildren(it)) {
+            if (already_touched(childiter)) continue;
+            descendants.push_back(childiter);
+        }
+        if (idx == descendants.size()) break;
+        it = descendants[idx];
+        ++idx;
+    }
 }
 
 void CTxMemPool::removeRecursive(const CTransaction &origTx, MemPoolRemovalReason reason)

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -452,25 +452,22 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
 // can save time by not iterating over those entries.
 void CTxMemPool::CalculateDescendants(txiter entryit, setEntries& setDescendants) const
 {
-    setEntries stage;
-    if (setDescendants.count(entryit) == 0) {
-        stage.insert(entryit);
-    }
+    if (!setDescendants.insert(entryit).second) return;
     // Traverse down the children of entry, only adding children that are not
     // accounted for in setDescendants already (because those children have either
     // already been walked, or will be walked in this iteration).
-    while (!stage.empty()) {
-        txiter it = *stage.begin();
-        setDescendants.insert(it);
-        stage.erase(it);
-
+    const uint64_t epoch = GetFreshEpoch();
+    txiter it = entryit;
+    std::vector<txiter> stack;
+    do {
         const setEntries &setChildren = GetMemPoolChildren(it);
         for (txiter childiter : setChildren) {
-            if (!setDescendants.count(childiter)) {
-                stage.insert(childiter);
-            }
+            if (childiter->already_touched(epoch)) continue;
+            if (!setDescendants.insert(childiter).second) continue;
+            stack.push_back(childiter);
         }
-    }
+    } while (!stack.empty() && (it = stack.back(), stack.pop_back(), true));
+
 }
 
 void CTxMemPool::removeRecursive(const CTransaction &origTx, MemPoolRemovalReason reason)

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -56,9 +56,10 @@ size_t CTxMemPoolEntry::GetTxSize() const
 // Update the given tx for any in-mempool descendants.
 // Assumes that setMemPoolChildren is correct for the given tx and all
 // descendants.
-void CTxMemPool::UpdateForDescendants(txiter updateIt, cacheMap &cachedDescendants, const std::set<uint256> &setExclude)
-{
-    auto func = [this] (txiter param_it, txiter update_it, int64_t&size, CAmount& fee, int64_t& count, cacheMap& cache, const std::set<uint256>& exclude, std::vector<txiter>& stack, bool& first_pass, const uint64_t epoch) {
+//
+void CTxMemPool::UpdateForDescendantsInner(txiter param_it, txiter update_it, int64_t&size, CAmount&
+        fee, int64_t& count, cacheMap& cache, const std::set<uint256>& exclude, std::vector<txiter>&
+        stack, bool update_child_epochs, const uint64_t epoch, const uint8_t limit) {
         auto make_state_update = [&](txiter cit) {
             if (exclude.count(cit->GetTx().GetHash())) return;
             size += cit->GetTxSize();
@@ -70,7 +71,7 @@ void CTxMemPool::UpdateForDescendants(txiter updateIt, cacheMap &cachedDescendan
         };
         auto& direct_children = GetMemPoolChildren(param_it);
         for (txiter cit : direct_children) {
-            if (first_pass) cit->already_touched(epoch);
+            if (update_child_epochs) cit->already_touched(epoch);
 
             // collect stats
             make_state_update(cit);
@@ -86,14 +87,18 @@ void CTxMemPool::UpdateForDescendants(txiter updateIt, cacheMap &cachedDescendan
                         if (cacheEntry->already_touched(epoch)) continue;
                         make_state_update(cacheEntry);
                     }
-                } else {
-                    // Schedule for later processing
+                } else if (limit == 0) {
+                    // Schedule for later processing, we're at the recursion limit
                     stack.push_back(childEntry);
+                } else {
+                    UpdateForDescendantsInner(childEntry, update_it, size, fee, count, cache,
+                            exclude, stack, false, epoch, limit-1);
                 }
             }
         }
-        first_pass = false;
     };
+void CTxMemPool::UpdateForDescendants(txiter updateIt, cacheMap &cachedDescendants, const std::set<uint256> &setExclude)
+{
     // Our children are natrually uniqueu
     std::vector<txiter> stack;
     uint64_t epoch = GetFreshEpoch();
@@ -103,11 +108,12 @@ void CTxMemPool::UpdateForDescendants(txiter updateIt, cacheMap &cachedDescendan
     int64_t modifyCount = 0;
 
     // Update and add to cached descendant map
-    auto main_it = updateIt;
     bool first_pass = true;
+    auto next_it = updateIt;
     do {
-        func(main_it, updateIt, modifySize, modifyFee, modifyCount, cachedDescendants, setExclude, stack, first_pass, epoch);
-    } while (!stack.empty() && (main_it = stack.back(), stack.pop_back(), true));
+        UpdateForDescendantsInner(next_it, updateIt, modifySize, modifyFee, modifyCount, cachedDescendants, setExclude, stack, first_pass, epoch);
+        first_pass = false;
+    } while (!stack.empty() && (next_it = stack.back(), stack.pop_back(), true));
     mapTx.modify(updateIt, update_descendant_state(modifySize, modifyFee, modifyCount));
 }
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -59,10 +59,10 @@ size_t CTxMemPoolEntry::GetTxSize() const
 //
 void CTxMemPool::UpdateForDescendantsInner(txiter param_it, txiter update_it, int64_t&size, CAmount&
         fee, int64_t& count, cacheMap& cache, const std::set<uint256>& exclude, vecEntries&
-        stack, bool update_child_epochs, const uint64_t epoch, const uint8_t limit) {
+        stack, bool update_child_epochs, const uint8_t limit) {
         auto& direct_children = GetMemPoolChildren(param_it);
         for (txiter cit : direct_children) {
-            if (update_child_epochs) cit->already_touched(epoch);
+            if (update_child_epochs) already_touched(cit);
 
             // collect stats
             if (!exclude.count(cit->GetTx().GetHash())) {
@@ -76,13 +76,13 @@ void CTxMemPool::UpdateForDescendantsInner(txiter param_it, txiter update_it, in
 
             const setEntries &setChildren = GetMemPoolChildren(cit);
             for (txiter childEntry : setChildren) {
-                if (childEntry->already_touched(epoch)) continue;
+                if (already_touched(childEntry)) continue;
                 cacheMap::iterator cacheIt = cache.find(childEntry);
                 if (cacheIt != cache.end()) {
                     // We've already calculated this one, just add the entries for this set
                     // but don't traverse again.
                     for (txiter cacheEntry : cacheIt->second) {
-                        if (cacheEntry->already_touched(epoch)) continue;
+                        if (already_touched(cacheEntry)) continue;
                         if (exclude.count(cacheEntry->GetTx().GetHash())) continue;
                         size += cacheEntry->GetTxSize();
                         fee += cacheEntry->GetModifiedFee();
@@ -96,7 +96,7 @@ void CTxMemPool::UpdateForDescendantsInner(txiter param_it, txiter update_it, in
                     stack.push_back(childEntry);
                 } else {
                     UpdateForDescendantsInner(childEntry, update_it, size, fee, count, cache,
-                            exclude, stack, false, epoch, limit-1);
+                            exclude, stack, false, limit-1);
                 }
             }
         }
@@ -105,7 +105,7 @@ void CTxMemPool::UpdateForDescendants(txiter updateIt, cacheMap &cachedDescendan
 {
     // Our children are natrually uniqueu
     vecEntries stack;
-    uint64_t epoch = GetFreshEpoch();
+    GetFreshEpoch();
 
     int64_t modifySize = 0;
     CAmount modifyFee = 0;
@@ -115,7 +115,7 @@ void CTxMemPool::UpdateForDescendants(txiter updateIt, cacheMap &cachedDescendan
     bool first_pass = true;
     auto next_it = updateIt;
     do {
-        UpdateForDescendantsInner(next_it, updateIt, modifySize, modifyFee, modifyCount, cachedDescendants, setExclude, stack, first_pass, epoch);
+        UpdateForDescendantsInner(next_it, updateIt, modifySize, modifyFee, modifyCount, cachedDescendants, setExclude, stack, first_pass);
         first_pass = false;
     } while (!stack.empty() && (next_it = stack.back(), stack.pop_back(), true));
     mapTx.modify(updateIt, update_descendant_state(modifySize, modifyFee, modifyCount));
@@ -145,7 +145,7 @@ void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<uint256> &vHashes
     // UpdateForDescendants.
     for (const uint256 &hash : reverse_iterate(vHashesToUpdate)) {
         // we cache the in-mempool children to avoid duplicate updates
-        uint64_t epoch = GetFreshEpoch();
+        GetFreshEpoch();
         // calculate children from mapNextTx
         txiter it = mapTx.find(hash);
         if (it == mapTx.end()) {
@@ -160,7 +160,7 @@ void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<uint256> &vHashes
             assert(childIter != mapTx.end());
             // We can skip updating entries we've encountered before or that
             // are in the block (which are already accounted for).
-            if (!childIter->already_touched(epoch) && !setAlreadyIncluded.count(childHash)) {
+            if (!already_touched(childIter) && !setAlreadyIncluded.count(childHash)) {
                 UpdateChild(it, childIter, true);
                 UpdateParent(childIter, it, true);
             }
@@ -173,20 +173,18 @@ bool CTxMemPool::CalculateMemPoolAncestors(const CTxMemPoolEntry &entry, vecEntr
 {
     assert(ancestors.size() == 0);
     const CTransaction &tx = entry.GetTx();
-    const uint64_t epoch = GetFreshEpoch();
+    GetFreshEpoch();
     if (fSearchForParents) {
         // Get parents of this transaction that are in the mempool
         // GetMemPoolParents() is only valid for entries in the mempool, so we
         // iterate mapTx to find parents.
         for (unsigned int i = 0; i < tx.vin.size(); i++) {
             Optional<txiter> piter = GetIter(tx.vin[i].prevout.hash);
-            if (piter) {
-                if ((*piter)->already_touched(epoch)) continue;
-                ancestors.push_back(*piter);
-                if (ancestors.size() + 1 > limitAncestorCount) {
-                    errString = strprintf("too many unconfirmed parents [limit: %u]", limitAncestorCount);
-                    return false;
-                }
+            if (already_touched(piter)) continue;
+            ancestors.push_back(*piter);
+            if (ancestors.size() + 1 > limitAncestorCount) {
+                errString = strprintf("too many unconfirmed parents [limit: %u]", limitAncestorCount);
+                return false;
             }
         }
     } else {
@@ -197,7 +195,7 @@ bool CTxMemPool::CalculateMemPoolAncestors(const CTxMemPoolEntry &entry, vecEntr
         ancestors.assign(ref_parents.cbegin(), ref_parents.cend());
         // touch before walking so we don't add a duplicate
         for (txiter it : ancestors) {
-            it->already_touched(epoch);
+            already_touched(it);
         }
     }
 
@@ -224,7 +222,7 @@ bool CTxMemPool::CalculateMemPoolAncestors(const CTxMemPoolEntry &entry, vecEntr
         const setEntries & setMemPoolParents = GetMemPoolParents(stageit);
         for (txiter phash : setMemPoolParents) {
             // If this is a new ancestor, add it.
-            if (phash->already_touched(epoch)) continue;
+            if (already_touched(phash)) continue;
             ancestors.push_back(phash);
             if (ancestors.size() + 1 > limitAncestorCount) {
                 errString = strprintf("too many unconfirmed ancestors [limit: %u]", limitAncestorCount);
@@ -286,6 +284,7 @@ void CTxMemPool::UpdateForRemoveFromMempool(const vecEntries &entriesToRemove, b
         // need to traverse the mempool).
         for (txiter removeIt : entriesToRemove) {
             vecEntries descendants;
+            GetFreshEpoch();
             CalculateDescendantsVec(removeIt, descendants);
             int64_t modifySize = -((int64_t)removeIt->GetTxSize());
             CAmount modifyFee = -removeIt->GetModifiedFee();
@@ -400,12 +399,12 @@ void CTxMemPool::addUnchecked(const CTxMemPoolEntry &entry, vecEntries &ancestor
     cachedInnerUsage += entry.DynamicMemoryUsage();
 
     const CTransaction& tx = newit->GetTx();
-    uint64_t epoch = GetFreshEpoch();
+    GetFreshEpoch();
     for (unsigned int i = 0; i < tx.vin.size(); i++) {
         mapNextTx.insert(std::make_pair(&tx.vin[i].prevout, &tx));
         // Update ancestors with information about this tx
         auto maybe_it = GetIter(tx.vin[i].prevout.hash);
-        if (maybe_it && !(*maybe_it)->already_touched(epoch)) UpdateParent(newit, *maybe_it, true);
+        if (!already_touched(maybe_it)) UpdateParent(newit, *maybe_it, true);
     }
     // Don't bother worrying about child transactions of this one.
     // Normal case of a new transaction arriving is that there can't be any
@@ -460,29 +459,24 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
 //
 // Note: it does not get inserted into the vector
 
-void CTxMemPool::CalculateDescendantsVec(txiter it, vecEntries& descendants, vecEntries& stack, const uint64_t epoch, const uint8_t limit) const
+void CTxMemPool::CalculateDescendantsVec(txiter it, vecEntries& descendants, vecEntries& stack, const uint8_t limit) const
 {
     for (txiter childiter : GetMemPoolChildren(it)) {
-        if (childiter->already_touched(epoch)) continue;
+        if (already_touched(childiter)) continue;
         descendants.push_back(childiter);
-        if (limit > 0) CalculateDescendantsVec(childiter, descendants, stack, epoch, limit-1);
+        if (limit > 0) CalculateDescendantsVec(childiter, descendants, stack, limit-1);
         else stack.push_back(childiter);
     }
 }
 
 void CTxMemPool::CalculateDescendantsVec(txiter entryit, vecEntries& descendants) const
 {
-    CalculateDescendantsVec(entryit, descendants, GetFreshEpoch());
-}
-
-void CTxMemPool::CalculateDescendantsVec(txiter entryit, vecEntries& descendants, const uint64_t cached_epoch) const
-{
     // Traverse down the children of entry, only adding children that are not marked as visited by
     // the epoch
     txiter it = entryit;
     vecEntries stack;
     do {
-        CalculateDescendantsVec(it, descendants, stack, cached_epoch);
+        CalculateDescendantsVec(it, descendants, stack);
     } while (!stack.empty() && (it = stack.back(), stack.pop_back(), true));
 }
 
@@ -499,28 +493,28 @@ void CTxMemPool::removeRecursive(const CTransaction &origTx, MemPoolRemovalReaso
             // be sure to remove any children that are in the pool. This can
             // happen during chain re-orgs if origTx isn't re-accepted into
             // the mempool for any reason.
-            const uint64_t epoch = GetFreshEpoch();
+            GetFreshEpoch();
             for (unsigned int i = 0; i < origTx.vout.size(); i++) {
                 auto it = mapNextTx.find(COutPoint(origTx.GetHash(), i));
                 if (it == mapNextTx.end())
                     continue;
                 txiter nextit = mapTx.find(it->second->GetHash());
                 assert(nextit != mapTx.end());
-                if (nextit->already_touched(epoch)) continue;
+                if (already_touched(nextit)) continue;
                 txToRemove.push_back(nextit);
             }
         }
-        const uint64_t epoch = GetFreshEpoch();
+        GetFreshEpoch();
         // touch all txToRemove first to force CalculateDescendantsVec
         // to not recurse if we're going to call it later.
         // This guarantees txToRemove gets no duplicates
         for (txiter it : txToRemove) {
-            it->already_touched(epoch);
+            already_touched(it);
         }
         // max_idx is used rather than iterator because txToRemove may grow
         const size_t max_idx = txToRemove.size();
         for (size_t idx = 0; idx < max_idx; ++idx) {
-            CalculateDescendantsVec(txToRemove[idx], txToRemove, epoch);
+            CalculateDescendantsVec(txToRemove[idx], txToRemove);
         }
 
         RemoveStaged(txToRemove, false, reason);
@@ -558,17 +552,17 @@ void CTxMemPool::removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMem
         }
     }
 
-    const uint64_t epoch = GetFreshEpoch();
+    GetFreshEpoch();
     // touch all txToRemove first to force CalculateDescendantsVec
     // to not recurse if we're going to call it later.
     // This guarantees txToRemove gets no duplicates
     for (txiter it : txToRemove) {
-        it->already_touched(epoch);
+        already_touched(it);
     }
     // max_idx is used rather than iterator because txToRemove may grow
     const size_t max_idx = txToRemove.size();
     for (size_t idx = 0; idx < max_idx; ++idx) {
-        CalculateDescendantsVec(txToRemove[idx], txToRemove, epoch);
+        CalculateDescendantsVec(txToRemove[idx], txToRemove);
     }
     RemoveStaged(txToRemove, false, MemPoolRemovalReason::REORG);
 
@@ -879,6 +873,7 @@ void CTxMemPool::PrioritiseTransaction(const uint256& hash, const CAmount& nFeeD
             }
             // Now update all descendants' modified fees with ancestors
             vecEntries descendants;
+            GetFreshEpoch();
             CalculateDescendantsVec(it, descendants);
             for (txiter descendantIt : descendants) {
                 mapTx.modify(descendantIt, update_ancestor_state(0, nFeeDelta, 0, 0));
@@ -978,10 +973,10 @@ int CTxMemPool::Expire(std::chrono::seconds time)
         it++;
     }
     vecEntries stage;
-    const uint64_t epoch = GetFreshEpoch();
+    GetFreshEpoch();
     for (txiter removeit : toremove) {
-        CalculateDescendantsVec(removeit, stage, epoch);
-        if (!removeit->already_touched(epoch))
+        CalculateDescendantsVec(removeit, stage);
+        if (!already_touched(removeit))
                 stage.push_back(removeit);
     }
     RemoveStaged(stage, false, MemPoolRemovalReason::EXPIRY);
@@ -1083,6 +1078,7 @@ void CTxMemPool::TrimToSize(size_t sizelimit, std::vector<COutPoint>* pvNoSpends
         maxFeeRateRemoved = std::max(maxFeeRateRemoved, removed);
 
         vecEntries stage;
+        GetFreshEpoch();
         CalculateDescendantsVec(mapTx.project<0>(it), stage);
         stage.push_back(mapTx.project<0>(it));
         nTxnRemoved += stage.size();

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -58,7 +58,7 @@ size_t CTxMemPoolEntry::GetTxSize() const
 // descendants.
 //
 void CTxMemPool::UpdateForDescendantsInner(txiter param_it, txiter update_it, int64_t&size, CAmount&
-        fee, int64_t& count, cacheMap& cache, const std::set<uint256>& exclude, std::vector<txiter>&
+        fee, int64_t& count, cacheMap& cache, const std::set<uint256>& exclude, vecEntries&
         stack, bool update_child_epochs, const uint64_t epoch, const uint8_t limit) {
         auto make_state_update = [&](txiter cit) {
             if (exclude.count(cit->GetTx().GetHash())) return;
@@ -100,7 +100,7 @@ void CTxMemPool::UpdateForDescendantsInner(txiter param_it, txiter update_it, in
 void CTxMemPool::UpdateForDescendants(txiter updateIt, cacheMap &cachedDescendants, const std::set<uint256> &setExclude)
 {
     // Our children are natrually uniqueu
-    std::vector<txiter> stack;
+    vecEntries stack;
     uint64_t epoch = GetFreshEpoch();
 
     int64_t modifySize = 0;
@@ -283,7 +283,7 @@ void CTxMemPool::UpdateForRemoveFromMempoolImpl(const T &entriesToRemove, bool u
         // we need to preserve until we're finished with all operations that
         // need to traverse the mempool).
         for (txiter removeIt : entriesToRemove) {
-            std::vector<txiter> descendants;
+            vecEntries descendants;
             CalculateDescendantsVec(removeIt, descendants);
             int64_t modifySize = -((int64_t)removeIt->GetTxSize());
             CAmount modifyFee = -removeIt->GetModifiedFee();
@@ -326,7 +326,7 @@ void CTxMemPool::UpdateForRemoveFromMempoolImpl(const T &entriesToRemove, bool u
         UpdateChildrenForRemoval(removeIt);
     }
 }
-void CTxMemPool::UpdateForRemoveFromMempool(const std::vector<txiter> &entriesToRemove, bool updateDescendants) {
+void CTxMemPool::UpdateForRemoveFromMempool(const vecEntries &entriesToRemove, bool updateDescendants) {
     UpdateForRemoveFromMempoolImpl(entriesToRemove, updateDescendants);
 }
 
@@ -456,16 +456,16 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
     if (minerPolicyEstimator) {minerPolicyEstimator->removeTx(hash, false);}
 }
 
-// Calculates descendants of entry that are not already in setDescendants, and adds to
-// setDescendants. Assumes entryit is already a tx in the mempool and setMemPoolChildren
+// Calculates descendants of entry that are not already in descendants, and adds to
+// descendants. Assumes entryit is already a tx in the mempool and setMemPoolChildren
 // is correct for tx and all descendants.
-// Also assumes that if an entry is in setDescendants already, then all
-// in-mempool descendants of it are already in setDescendants as well, so that we
+// Also assumes that if an entry is in descendants already, then all
+// in-mempool descendants of it are already in descendants as well, so that we
 // can save time by not iterating over those entries.
 //
 // Note: it does not get inserted into the vector
 
-void CTxMemPool::CalculateDescendantsVec(txiter it, std::vector<txiter>& descendants, std::vector<txiter>& stack, const uint64_t epoch, const uint8_t limit) const
+void CTxMemPool::CalculateDescendantsVec(txiter it, vecEntries& descendants, vecEntries& stack, const uint64_t epoch, const uint8_t limit) const
 {
     for (txiter childiter : GetMemPoolChildren(it)) {
         if (childiter->already_touched(epoch)) continue;
@@ -475,17 +475,17 @@ void CTxMemPool::CalculateDescendantsVec(txiter it, std::vector<txiter>& descend
     }
 }
 
-void CTxMemPool::CalculateDescendantsVec(txiter entryit, std::vector<txiter>& descendants) const
+void CTxMemPool::CalculateDescendantsVec(txiter entryit, vecEntries& descendants) const
 {
     CalculateDescendantsVec(entryit, descendants, GetFreshEpoch());
 }
 
-void CTxMemPool::CalculateDescendantsVec(txiter entryit, std::vector<txiter>& descendants, const uint64_t cached_epoch) const
+void CTxMemPool::CalculateDescendantsVec(txiter entryit, vecEntries& descendants, const uint64_t cached_epoch) const
 {
     // Traverse down the children of entry, only adding children that are not marked as visited by
     // the epoch
     txiter it = entryit;
-    std::vector<txiter> stack;
+    vecEntries stack;
     do {
         CalculateDescendantsVec(it, descendants, stack, cached_epoch);
     } while (!stack.empty() && (it = stack.back(), stack.pop_back(), true));
@@ -513,15 +513,15 @@ void CTxMemPool::removeRecursive(const CTransaction &origTx, MemPoolRemovalReaso
                 txToRemove.insert(nextit);
             }
         }
-        std::vector<txiter> setAllRemoves;
+        vecEntries all_removes;
         const uint64_t epoch = GetFreshEpoch();
         for (txiter it : txToRemove) {
-            CalculateDescendantsVec(it, setAllRemoves, epoch);
+            CalculateDescendantsVec(it, all_removes, epoch);
             if (!it->already_touched(epoch))
-                setAllRemoves.push_back(it);
+                all_removes.push_back(it);
         }
 
-        RemoveStaged(setAllRemoves, false, reason);
+        RemoveStaged(all_removes, false, reason);
 }
 
 void CTxMemPool::removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMemPoolHeight, int flags)
@@ -554,14 +554,14 @@ void CTxMemPool::removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMem
             mapTx.modify(it, update_lock_points(lp));
         }
     }
-    std::vector<txiter> setAllRemoves;
+    vecEntries all_removes;
     const uint64_t epoch = GetFreshEpoch();
     for (txiter it : txToRemove) {
-        CalculateDescendantsVec(it, setAllRemoves, epoch);
+        CalculateDescendantsVec(it, all_removes, epoch);
         if (!it->already_touched(epoch))
-                setAllRemoves.push_back(it);
+                all_removes.push_back(it);
     }
-    RemoveStaged(setAllRemoves, false, MemPoolRemovalReason::REORG);
+    RemoveStaged(all_removes, false, MemPoolRemovalReason::REORG);
 }
 
 void CTxMemPool::removeConflicts(const CTransaction &tx)
@@ -602,7 +602,7 @@ void CTxMemPool::removeForBlock(const std::vector<CTransactionRef>& vtx, unsigne
     {
         txiter it = mapTx.find(tx->GetHash());
         if (it != mapTx.end()) {
-            std::vector<txiter> stage{it};
+            vecEntries stage{it};
             RemoveStaged(stage, true, MemPoolRemovalReason::BLOCK);
         }
         removeConflicts(*tx);
@@ -868,9 +868,9 @@ void CTxMemPool::PrioritiseTransaction(const uint256& hash, const CAmount& nFeeD
                 mapTx.modify(ancestorIt, update_descendant_state(0, nFeeDelta, 0));
             }
             // Now update all descendants' modified fees with ancestors
-            std::vector<txiter> setDescendants;
-            CalculateDescendantsVec(it, setDescendants);
-            for (txiter descendantIt : setDescendants) {
+            vecEntries descendants;
+            CalculateDescendantsVec(it, descendants);
+            for (txiter descendantIt : descendants) {
                 mapTx.modify(descendantIt, update_ancestor_state(0, nFeeDelta, 0, 0));
             }
             ++nTransactionsUpdated;
@@ -959,7 +959,7 @@ void CTxMemPool::RemoveStagedImpl(T &stage, bool updateDescendants, MemPoolRemov
     }
 }
 
-void CTxMemPool::RemoveStaged(std::vector<txiter> &stage, bool updateDescendants, MemPoolRemovalReason reason) {
+void CTxMemPool::RemoveStaged(vecEntries &stage, bool updateDescendants, MemPoolRemovalReason reason) {
     RemoveStagedImpl(stage, updateDescendants, reason);
 }
 void CTxMemPool::RemoveStaged(setEntries &stage, bool updateDescendants, MemPoolRemovalReason reason) {
@@ -975,7 +975,7 @@ int CTxMemPool::Expire(std::chrono::seconds time)
         toremove.insert(mapTx.project<0>(it));
         it++;
     }
-    std::vector<txiter> stage;
+    vecEntries stage;
     const uint64_t epoch = GetFreshEpoch();
     for (txiter removeit : toremove) {
         CalculateDescendantsVec(removeit, stage, epoch);
@@ -1080,7 +1080,7 @@ void CTxMemPool::TrimToSize(size_t sizelimit, std::vector<COutPoint>* pvNoSpends
         trackPackageRemoved(removed);
         maxFeeRateRemoved = std::max(maxFeeRateRemoved, removed);
 
-        std::vector<txiter> stage;
+        vecEntries stage;
         CalculateDescendantsVec(mapTx.project<0>(it), stage);
         stage.push_back(mapTx.project<0>(it));
         nTxnRemoved += stage.size();
@@ -1109,7 +1109,7 @@ void CTxMemPool::TrimToSize(size_t sizelimit, std::vector<COutPoint>* pvNoSpends
 
 uint64_t CTxMemPool::CalculateDescendantMaximum(txiter entry) const {
     // find parent with highest descendant count
-    std::vector<txiter> candidates;
+    vecEntries candidates;
     setEntries counted;
     candidates.push_back(entry);
     uint64_t maximum = 0;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -60,21 +60,19 @@ size_t CTxMemPoolEntry::GetTxSize() const
 void CTxMemPool::UpdateForDescendantsInner(txiter param_it, txiter update_it, int64_t&size, CAmount&
         fee, int64_t& count, cacheMap& cache, const std::set<uint256>& exclude, vecEntries&
         stack, bool update_child_epochs, const uint64_t epoch, const uint8_t limit) {
-        auto make_state_update = [&](txiter cit) {
-            if (exclude.count(cit->GetTx().GetHash())) return;
-            size += cit->GetTxSize();
-            fee += cit->GetModifiedFee();
-            count++;
-            cache[update_it].insert(cit);
-            // Update ancestor state for each descendant
-            mapTx.modify(cit, update_ancestor_state(update_it->GetTxSize(), update_it->GetModifiedFee(), 1, update_it->GetSigOpCost()));
-        };
         auto& direct_children = GetMemPoolChildren(param_it);
         for (txiter cit : direct_children) {
             if (update_child_epochs) cit->already_touched(epoch);
 
             // collect stats
-            make_state_update(cit);
+            if (!exclude.count(cit->GetTx().GetHash())) {
+                size += cit->GetTxSize();
+                fee += cit->GetModifiedFee();
+                count++;
+                cache[update_it].insert(cit);
+                // Update ancestor state for each descendant
+                mapTx.modify(cit, update_ancestor_state(update_it->GetTxSize(), update_it->GetModifiedFee(), 1, update_it->GetSigOpCost()));
+            }
 
             const setEntries &setChildren = GetMemPoolChildren(cit);
             for (txiter childEntry : setChildren) {
@@ -85,7 +83,13 @@ void CTxMemPool::UpdateForDescendantsInner(txiter param_it, txiter update_it, in
                     // but don't traverse again.
                     for (txiter cacheEntry : cacheIt->second) {
                         if (cacheEntry->already_touched(epoch)) continue;
-                        make_state_update(cacheEntry);
+                        if (exclude.count(cacheEntry->GetTx().GetHash())) continue;
+                        size += cacheEntry->GetTxSize();
+                        fee += cacheEntry->GetModifiedFee();
+                        count++;
+                        cache[update_it].insert(cacheEntry);
+                        // Update ancestor state for each descendant
+                        mapTx.modify(cacheEntry, update_ancestor_state(update_it->GetTxSize(), update_it->GetModifiedFee(), 1, update_it->GetSigOpCost()));
                     }
                 } else if (limit == 0) {
                     // Schedule for later processing, we're at the recursion limit

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -58,18 +58,38 @@ size_t CTxMemPoolEntry::GetTxSize() const
 // descendants.
 void CTxMemPool::UpdateForDescendants(txiter updateIt, cacheMap &cachedDescendants, const std::set<uint256> &setExclude)
 {
-    auto& direct_children = GetMemPoolChildren(updateIt);
     // Our children are natrually uniqueu
-    std::vector<txiter> all_descendants{direct_children.cbegin(), direct_children.cend()};
     std::vector<txiter> stack;
     uint64_t epoch = GetFreshEpoch();
 
+    int64_t modifySize = 0;
+    CAmount modifyFee = 0;
+    int64_t modifyCount = 0;
+    auto make_state_update = [&](txiter cit) {
+        if (!setExclude.count(cit->GetTx().GetHash())) {
+            modifySize += cit->GetTxSize();
+            modifyFee += cit->GetModifiedFee();
+            modifyCount++;
+            cachedDescendants[updateIt].insert(cit);
+            // Update ancestor state for each descendant
+            mapTx.modify(cit, update_ancestor_state(updateIt->GetTxSize(), updateIt->GetModifiedFee(), 1, updateIt->GetSigOpCost()));
+        }
+    };
+
+    // Update and add to cached descendant map
+    auto& direct_children = GetMemPoolChildren(updateIt);
     auto children_it = direct_children.begin();
     while (children_it != direct_children.end() || !stack.empty()) {
         // Either pop the stack or read from the direct_children
         bool have_direct_children = children_it != direct_children.end();
         const txiter cit =  have_direct_children ? *(children_it++) : stack.back();
+        // if on the stack already touched (but remove)
+        // touch the direct_children
         if (!have_direct_children) stack.pop_back();
+        else cit->already_touched(epoch);
+
+        // collect stats
+        make_state_update(cit);
 
         const setEntries &setChildren = GetMemPoolChildren(cit);
         for (txiter childEntry : setChildren) {
@@ -80,28 +100,12 @@ void CTxMemPool::UpdateForDescendants(txiter updateIt, cacheMap &cachedDescendan
                 // but don't traverse again.
                 for (txiter cacheEntry : cacheIt->second) {
                     if (cacheEntry->already_touched(epoch)) continue;
-                    all_descendants.push_back(cacheEntry);
+                    make_state_update(cacheEntry);
                 }
             } else {
                 // Schedule for later processing
                 stack.push_back(childEntry);
-                all_descendants.push_back(childEntry);
             }
-        }
-    }
-    // setAllDescendants now contains all in-mempool descendants of updateIt.
-    // Update and add to cached descendant map
-    int64_t modifySize = 0;
-    CAmount modifyFee = 0;
-    int64_t modifyCount = 0;
-    for (txiter cit : all_descendants) {
-        if (!setExclude.count(cit->GetTx().GetHash())) {
-            modifySize += cit->GetTxSize();
-            modifyFee += cit->GetModifiedFee();
-            modifyCount++;
-            cachedDescendants[updateIt].insert(cit);
-            // Update ancestor state for each descendant
-            mapTx.modify(cit, update_ancestor_state(updateIt->GetTxSize(), updateIt->GetModifiedFee(), 1, updateIt->GetSigOpCost()));
         }
     }
     mapTx.modify(updateIt, update_descendant_state(modifySize, modifyFee, modifyCount));

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -60,8 +60,9 @@ size_t CTxMemPoolEntry::GetTxSize() const
 void CTxMemPool::UpdateForDescendantsInner(txiter param_it, txiter update_it, int64_t&size, CAmount&
         fee, int64_t& count, cacheMap& cache, const std::set<uint256>& exclude, vecEntries&
         stack, bool update_child_epochs, const uint8_t limit) {
-        auto& direct_children = GetMemPoolChildren(param_it);
-        for (txiter cit : direct_children) {
+        const auto& direct_children = param_it->GetMemPoolChildrenConst();
+        for (const auto& p_it : direct_children) {
+            auto cit = mapTx.iterator_to(p_it);
             if (update_child_epochs) already_touched(cit);
 
             // collect stats
@@ -74,8 +75,9 @@ void CTxMemPool::UpdateForDescendantsInner(txiter param_it, txiter update_it, in
                 mapTx.modify(cit, update_ancestor_state(update_it->GetTxSize(), update_it->GetModifiedFee(), 1, update_it->GetSigOpCost()));
             }
 
-            const setEntries &setChildren = GetMemPoolChildren(cit);
-            for (txiter childEntry : setChildren) {
+            const CTxMemPoolEntry::relatives &setChildren = cit->GetMemPoolChildrenConst();
+            for (const auto& pchildEntry : setChildren) {
+                auto childEntry = mapTx.iterator_to(pchildEntry);
                 if (already_touched(childEntry)) continue;
                 cacheMap::iterator cacheIt = cache.find(childEntry);
                 if (cacheIt != cache.end()) {
@@ -193,11 +195,12 @@ bool CTxMemPool::CalculateMemPoolAncestors(const CTxMemPoolEntry &entry, vecEntr
         // If we're not searching for parents, we require this to be an
         // entry in the mempool already.
         txiter it = mapTx.iterator_to(entry);
-        auto& ref_parents = GetMemPoolParents(it);
-        ancestors.assign(ref_parents.cbegin(), ref_parents.cend());
-        // touch before walking so we don't add a duplicate
-        for (txiter it : ancestors) {
-            already_touched(it);
+        const auto& ref_parents = it->GetMemPoolParentsConst();
+        ancestors.reserve(ref_parents.size());
+        for (const auto& parent: ref_parents) {
+            ancestors.emplace_back(mapTx.iterator_to(parent));
+            // touch before walking so we don't add a duplicate
+            already_touched(ancestors.back());
         }
     }
 
@@ -221,8 +224,9 @@ bool CTxMemPool::CalculateMemPoolAncestors(const CTxMemPoolEntry &entry, vecEntr
             return false;
         }
 
-        const setEntries & setMemPoolParents = GetMemPoolParents(stageit);
-        for (txiter phash : setMemPoolParents) {
+        const CTxMemPoolEntry::relatives& setMemPoolParents = stageit->GetMemPoolParentsConst();
+        for (auto pphash : setMemPoolParents) {
+            auto phash = mapTx.iterator_to(pphash);
             // If this is a new ancestor, add it.
             if (already_touched(phash)) continue;
             ancestors.push_back(phash);
@@ -238,10 +242,10 @@ bool CTxMemPool::CalculateMemPoolAncestors(const CTxMemPoolEntry &entry, vecEntr
 
 void CTxMemPool::UpdateAncestorsOf(bool add, txiter it, vecEntries &ancestors)
 {
-    setEntries parentIters = GetMemPoolParents(it);
+    const CTxMemPoolEntry::relatives& parentIters = it->GetMemPoolParentsConst();
     // add or remove this tx as a child of each parent
-    for (txiter piter : parentIters) {
-        UpdateChild(piter, it, add);
+    for (const auto& piter : parentIters) {
+        UpdateChild(mapTx.iterator_to(piter), it, add);
     }
     const int64_t updateCount = (add ? 1 : -1);
     const int64_t updateSize = updateCount * it->GetTxSize();
@@ -267,9 +271,9 @@ void CTxMemPool::UpdateEntryForAncestors(txiter it, const vecEntries &ancestors)
 
 void CTxMemPool::UpdateChildrenForRemoval(txiter it)
 {
-    const setEntries &setMemPoolChildren = GetMemPoolChildren(it);
-    for (txiter updateIt : setMemPoolChildren) {
-        UpdateParent(updateIt, it, false);
+    const CTxMemPoolEntry::relatives &setMemPoolChildren = it->GetMemPoolChildrenConst();
+    for (const auto& updateIt : setMemPoolChildren) {
+        UpdateParent(mapTx.iterator_to(updateIt), it, false);
     }
 }
 
@@ -384,7 +388,6 @@ void CTxMemPool::addUnchecked(const CTxMemPoolEntry &entry, vecEntries &ancestor
     // Used by AcceptToMemoryPool(), which DOES do
     // all the appropriate checks.
     indexed_transaction_set::iterator newit = mapTx.insert(entry).first;
-    mapLinks.insert(make_pair(newit, TxLinks()));
 
     // Update transaction for any feeDelta created by PrioritiseTransaction
     // TODO: refactor so that the fee delta is calculated before inserting
@@ -448,8 +451,7 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
 
     totalTxSize -= it->GetTxSize();
     cachedInnerUsage -= it->DynamicMemoryUsage();
-    cachedInnerUsage -= memusage::DynamicUsage(mapLinks[it].parents) + memusage::DynamicUsage(mapLinks[it].children);
-    mapLinks.erase(it);
+    cachedInnerUsage -= memusage::DynamicUsage(it->GetMemPoolParentsConst()) + memusage::DynamicUsage(it->GetMemPoolChildrenConst());
     mapTx.erase(it);
     nTransactionsUpdated++;
     if (minerPolicyEstimator) {minerPolicyEstimator->removeTx(hash, false);}
@@ -470,7 +472,8 @@ void CTxMemPool::CalculateDescendantsVec(txiter entryit, vecEntries& descendants
     txiter it = entryit;
     size_t idx = descendants.size();
     while (true) {
-        for (const auto& childiter : GetMemPoolChildren(it)) {
+        for (const auto& pchilditer : it->GetMemPoolChildrenConst()) {
+            auto childiter = mapTx.iterator_to(pchilditer);
             if (already_touched(childiter)) continue;
             descendants.push_back(childiter);
         }
@@ -617,7 +620,6 @@ void CTxMemPool::removeForBlock(const std::vector<CTransactionRef>& vtx, unsigne
 
 void CTxMemPool::_clear()
 {
-    mapLinks.clear();
     mapTx.clear();
     mapNextTx.clear();
     totalTxSize = 0;
@@ -668,12 +670,9 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
         checkTotal += it->GetTxSize();
         innerUsage += it->DynamicMemoryUsage();
         const CTransaction& tx = it->GetTx();
-        txlinksMap::const_iterator linksiter = mapLinks.find(it);
-        assert(linksiter != mapLinks.end());
-        const TxLinks &links = linksiter->second;
-        innerUsage += memusage::DynamicUsage(links.parents) + memusage::DynamicUsage(links.children);
+        innerUsage += memusage::DynamicUsage(it->GetMemPoolParentsConst()) + memusage::DynamicUsage(it->GetMemPoolChildrenConst());
         bool fDependsWait = false;
-        setEntries setParentCheck;
+        CTxMemPoolEntry::relatives setParentCheck;
         for (const CTxIn &txin : tx.vin) {
             // Check that every mempool transaction's inputs refer to available coins, or other mempool tx's.
             indexed_transaction_set::const_iterator it2 = mapTx.find(txin.prevout.hash);
@@ -681,7 +680,7 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
                 const CTransaction& tx2 = it2->GetTx();
                 assert(tx2.vout.size() > txin.prevout.n && !tx2.vout[txin.prevout.n].IsNull());
                 fDependsWait = true;
-                setParentCheck.insert(it2);
+                setParentCheck.insert(*it2);
             } else {
                 assert(pcoins->HaveCoin(txin.prevout));
             }
@@ -692,7 +691,12 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
             assert(it3->second == &tx);
             i++;
         }
-        assert(setParentCheck == GetMemPoolParents(it));
+        const auto rel_eq = [](const CTxMemPoolEntry::relatives& one, const CTxMemPoolEntry::relatives& two) -> bool {
+            const auto eq = [](const std::reference_wrapper<const CTxMemPoolEntry>& a,
+                        const std::reference_wrapper<const CTxMemPoolEntry>& b) -> bool { return &(a.get()) == &(b.get()); };
+            return one.size() == two.size() && std::equal(one.cbegin(), one.cend(), two.cbegin(), eq);
+        };
+        assert(rel_eq(setParentCheck, it->GetMemPoolParentsConst()));
         // Verify ancestor state is correct.
         vecEntries ancestors;
         uint64_t nNoLimit = std::numeric_limits<uint64_t>::max();
@@ -715,17 +719,17 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
         assert(it->GetModFeesWithAncestors() == nFeesCheck);
 
         // Check children against mapNextTx
-        CTxMemPool::setEntries setChildrenCheck;
+        CTxMemPoolEntry::relatives setChildrenCheck;
         auto iter = mapNextTx.lower_bound(COutPoint(it->GetTx().GetHash(), 0));
         uint64_t child_sizes = 0;
         for (; iter != mapNextTx.end() && iter->first->hash == it->GetTx().GetHash(); ++iter) {
             txiter childit = mapTx.find(iter->second->GetHash());
             assert(childit != mapTx.end()); // mapNextTx points to in-mempool transactions
-            if (setChildrenCheck.insert(childit).second) {
+            if (setChildrenCheck.insert(*childit).second) {
                 child_sizes += childit->GetTxSize();
             }
         }
-        assert(setChildrenCheck == GetMemPoolChildren(it));
+        assert(rel_eq(setChildrenCheck, it->GetMemPoolChildren()));
         // Also check to make sure size is greater than sum with immediate children.
         // just a sanity check, not definitive that this calc is correct...
         assert(it->GetSizeWithDescendants() >= child_sizes + it->GetTxSize());
@@ -953,7 +957,7 @@ bool CCoinsViewMemPool::GetCoin(const COutPoint &outpoint, Coin &coin) const {
 size_t CTxMemPool::DynamicMemoryUsage() const {
     LOCK(cs);
     // Estimate the overhead of mapTx to be 12 pointers + an allocation, as no exact formula for boost::multi_index_contained is implemented.
-    return memusage::MallocUsage(sizeof(CTxMemPoolEntry) + 12 * sizeof(void*)) * mapTx.size() + memusage::DynamicUsage(mapNextTx) + memusage::DynamicUsage(mapDeltas) + memusage::DynamicUsage(mapLinks) + memusage::DynamicUsage(vTxHashes) + cachedInnerUsage;
+    return memusage::MallocUsage(sizeof(CTxMemPoolEntry) + 12 * sizeof(void*)) * mapTx.size() + memusage::DynamicUsage(mapNextTx) + memusage::DynamicUsage(mapDeltas) + memusage::DynamicUsage(vTxHashes) + cachedInnerUsage;
 }
 
 void CTxMemPool::RemoveStaged(vecEntries &stage, bool updateDescendants, MemPoolRemovalReason reason) {
@@ -998,9 +1002,9 @@ void CTxMemPool::addUnchecked(const CTxMemPoolEntry &entry, bool validFeeEstimat
 void CTxMemPool::UpdateChild(txiter entry, txiter child, bool add)
 {
     setEntries s;
-    if (add && mapLinks[entry].children.insert(child).second) {
+    if (add && entry->GetMemPoolChildren().insert(*child).second) {
         cachedInnerUsage += memusage::IncrementalDynamicUsage(s);
-    } else if (!add && mapLinks[entry].children.erase(child)) {
+    } else if (!add && entry->GetMemPoolChildren().erase(*child)) {
         cachedInnerUsage -= memusage::IncrementalDynamicUsage(s);
     }
 }
@@ -1008,27 +1012,11 @@ void CTxMemPool::UpdateChild(txiter entry, txiter child, bool add)
 void CTxMemPool::UpdateParent(txiter entry, txiter parent, bool add)
 {
     setEntries s;
-    if (add && mapLinks[entry].parents.insert(parent).second) {
+    if (add && entry->GetMemPoolParents().insert(*parent).second) {
         cachedInnerUsage += memusage::IncrementalDynamicUsage(s);
-    } else if (!add && mapLinks[entry].parents.erase(parent)) {
+    } else if (!add && entry->GetMemPoolParents().erase(*parent)) {
         cachedInnerUsage -= memusage::IncrementalDynamicUsage(s);
     }
-}
-
-const CTxMemPool::setEntries & CTxMemPool::GetMemPoolParents(txiter entry) const
-{
-    assert (entry != mapTx.end());
-    txlinksMap::const_iterator it = mapLinks.find(entry);
-    assert(it != mapLinks.end());
-    return it->second.parents;
-}
-
-const CTxMemPool::setEntries & CTxMemPool::GetMemPoolChildren(txiter entry) const
-{
-    assert (entry != mapTx.end());
-    txlinksMap::const_iterator it = mapLinks.find(entry);
-    assert(it != mapLinks.end());
-    return it->second.children;
 }
 
 CFeeRate CTxMemPool::GetMinFee(size_t sizelimit) const {
@@ -1112,19 +1100,19 @@ void CTxMemPool::TrimToSize(size_t sizelimit, std::vector<COutPoint>* pvNoSpends
 
 uint64_t CTxMemPool::CalculateDescendantMaximum(txiter entry) const {
     // find parent with highest descendant count
-    vecEntries candidates;
+    std::vector<std::reference_wrapper<const CTxMemPoolEntry>> candidates;
     setEntries counted;
-    candidates.push_back(entry);
+    candidates.push_back(*entry);
     uint64_t maximum = 0;
     while (candidates.size()) {
-        txiter candidate = candidates.back();
+        const CTxMemPoolEntry& candidate = candidates.back();
         candidates.pop_back();
-        if (!counted.insert(candidate).second) continue;
-        const setEntries& parents = GetMemPoolParents(candidate);
+        if (!counted.insert(mapTx.iterator_to(candidate)).second) continue;
+        const CTxMemPoolEntry::relatives& parents = candidate.GetMemPoolParentsConst();
         if (parents.size() == 0) {
-            maximum = std::max(maximum, candidate->GetCountWithDescendants());
+            maximum = std::max(maximum, candidate.GetCountWithDescendants());
         } else {
-            for (txiter i : parents) {
+            for (const auto& i : parents) {
                 candidates.push_back(i);
             }
         }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -167,17 +167,18 @@ void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<uint256> &vHashes
 
 bool CTxMemPool::CalculateMemPoolAncestors(const CTxMemPoolEntry &entry, setEntries &setAncestors, uint64_t limitAncestorCount, uint64_t limitAncestorSize, uint64_t limitDescendantCount, uint64_t limitDescendantSize, std::string &errString, bool fSearchForParents /* = true */) const
 {
-    setEntries parentHashes;
+    std::vector<txiter> parentHashes;
     const CTransaction &tx = entry.GetTx();
-
     if (fSearchForParents) {
+        const uint64_t epoch = GetFreshEpoch();
         // Get parents of this transaction that are in the mempool
         // GetMemPoolParents() is only valid for entries in the mempool, so we
         // iterate mapTx to find parents.
         for (unsigned int i = 0; i < tx.vin.size(); i++) {
             Optional<txiter> piter = GetIter(tx.vin[i].prevout.hash);
             if (piter) {
-                parentHashes.insert(*piter);
+                if ((*piter)->already_touched(epoch)) continue;
+                parentHashes.push_back(*piter);
                 if (parentHashes.size() + 1 > limitAncestorCount) {
                     errString = strprintf("too many unconfirmed parents [limit: %u]", limitAncestorCount);
                     return false;
@@ -188,16 +189,19 @@ bool CTxMemPool::CalculateMemPoolAncestors(const CTxMemPoolEntry &entry, setEntr
         // If we're not searching for parents, we require this to be an
         // entry in the mempool already.
         txiter it = mapTx.iterator_to(entry);
-        parentHashes = GetMemPoolParents(it);
+        auto& ref_parents = GetMemPoolParents(it);
+        parentHashes.assign(ref_parents.cbegin(), ref_parents.cend());
     }
 
     size_t totalSizeWithAncestors = entry.GetTxSize();
 
+    const uint64_t epoch = GetFreshEpoch();
     while (!parentHashes.empty()) {
-        txiter stageit = *parentHashes.begin();
+        txiter stageit = parentHashes.back();
+        stageit->already_touched(epoch);
+        parentHashes.pop_back();
 
         setAncestors.insert(stageit);
-        parentHashes.erase(stageit);
         totalSizeWithAncestors += stageit->GetTxSize();
 
         if (stageit->GetSizeWithDescendants() + entry.GetTxSize() > limitDescendantSize) {
@@ -214,8 +218,9 @@ bool CTxMemPool::CalculateMemPoolAncestors(const CTxMemPoolEntry &entry, setEntr
         const setEntries & setMemPoolParents = GetMemPoolParents(stageit);
         for (txiter phash : setMemPoolParents) {
             // If this is a new ancestor, add it.
+            if (phash->already_touched(epoch)) continue;
             if (setAncestors.count(phash) == 0) {
-                parentHashes.insert(phash);
+                parentHashes.push_back(phash);
             }
             if (parentHashes.size() + setAncestors.size() + 1 > limitAncestorCount) {
                 errString = strprintf("too many unconfirmed ancestors [limit: %u]", limitAncestorCount);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -165,9 +165,9 @@ void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<uint256> &vHashes
     }
 }
 
-bool CTxMemPool::CalculateMemPoolAncestors(const CTxMemPoolEntry &entry, setEntries &setAncestors, uint64_t limitAncestorCount, uint64_t limitAncestorSize, uint64_t limitDescendantCount, uint64_t limitDescendantSize, std::string &errString, bool fSearchForParents /* = true */) const
+bool CTxMemPool::CalculateMemPoolAncestors(const CTxMemPoolEntry &entry, vecEntries &ancestors, uint64_t limitAncestorCount, uint64_t limitAncestorSize, uint64_t limitDescendantCount, uint64_t limitDescendantSize, std::string &errString, bool fSearchForParents /* = true */) const
 {
-    std::vector<txiter> ancestors;
+    assert(ancestors.size() == 0);
     const CTransaction &tx = entry.GetTx();
     const uint64_t epoch = GetFreshEpoch();
     if (fSearchForParents) {
@@ -221,22 +221,18 @@ bool CTxMemPool::CalculateMemPoolAncestors(const CTxMemPoolEntry &entry, setEntr
         for (txiter phash : setMemPoolParents) {
             // If this is a new ancestor, add it.
             if (phash->already_touched(epoch)) continue;
-            if (setAncestors.count(phash) == 0) {
-                ancestors.push_back(phash);
-            }
-            if (setAncestors.size() + ancestors.size() + 1 > limitAncestorCount) {
+            ancestors.push_back(phash);
+            if (ancestors.size() + 1 > limitAncestorCount) {
                 errString = strprintf("too many unconfirmed ancestors [limit: %u]", limitAncestorCount);
                 return false;
             }
         }
     }
-    // This is just to preserve the output type for now
-    for (txiter ancestor : ancestors) setAncestors.insert(ancestor);
 
     return true;
 }
 
-void CTxMemPool::UpdateAncestorsOf(bool add, txiter it, setEntries &setAncestors)
+void CTxMemPool::UpdateAncestorsOf(bool add, txiter it, vecEntries &setAncestors)
 {
     setEntries parentIters = GetMemPoolParents(it);
     // add or remove this tx as a child of each parent
@@ -251,7 +247,7 @@ void CTxMemPool::UpdateAncestorsOf(bool add, txiter it, setEntries &setAncestors
     }
 }
 
-void CTxMemPool::UpdateEntryForAncestors(txiter it, const setEntries &setAncestors)
+void CTxMemPool::UpdateEntryForAncestors(txiter it, const vecEntries &setAncestors)
 {
     int64_t updateCount = setAncestors.size();
     int64_t updateSize = 0;
@@ -298,7 +294,7 @@ void CTxMemPool::UpdateForRemoveFromMempoolImpl(const T &entriesToRemove, bool u
         }
     }
     for (txiter removeIt : entriesToRemove) {
-        setEntries setAncestors;
+        vecEntries setAncestors;
         const CTxMemPoolEntry &entry = *removeIt;
         std::string dummy;
         // Since this is a tx that is already in the mempool, we can call CMPA
@@ -385,7 +381,7 @@ void CTxMemPool::AddTransactionsUpdated(unsigned int n)
     nTransactionsUpdated += n;
 }
 
-void CTxMemPool::addUnchecked(const CTxMemPoolEntry &entry, setEntries &setAncestors, bool validFeeEstimate)
+void CTxMemPool::addUnchecked(const CTxMemPoolEntry &entry, vecEntries &setAncestors, bool validFeeEstimate)
 {
     NotifyEntryAdded(entry.GetSharedTx());
     // Add to memory pool without checking anything.
@@ -719,7 +715,7 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
         }
         assert(setParentCheck == GetMemPoolParents(it));
         // Verify ancestor state is correct.
-        setEntries setAncestors;
+        vecEntries setAncestors;
         uint64_t nNoLimit = std::numeric_limits<uint64_t>::max();
         std::string dummy;
         CalculateMemPoolAncestors(*it, setAncestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy);
@@ -890,7 +886,7 @@ void CTxMemPool::PrioritiseTransaction(const uint256& hash, const CAmount& nFeeD
         if (it != mapTx.end()) {
             mapTx.modify(it, update_fee_delta(delta));
             // Now update all ancestors' modified fees with descendants
-            setEntries setAncestors;
+            vecEntries setAncestors;
             uint64_t nNoLimit = std::numeric_limits<uint64_t>::max();
             std::string dummy;
             CalculateMemPoolAncestors(*it, setAncestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy, false);
@@ -1018,7 +1014,7 @@ int CTxMemPool::Expire(std::chrono::seconds time)
 
 void CTxMemPool::addUnchecked(const CTxMemPoolEntry &entry, bool validFeeEstimate)
 {
-    setEntries setAncestors;
+    vecEntries setAncestors;
     uint64_t nNoLimit = std::numeric_limits<uint64_t>::max();
     std::string dummy;
     CalculateMemPoolAncestors(entry, setAncestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -79,7 +79,7 @@ void CTxMemPool::UpdateForDescendants(txiter updateIt, cacheMap &cachedDescendan
     // Update and add to cached descendant map
     auto main_it = updateIt;
     bool first_pass = true;
-    do {
+    auto func = [&] (txiter param_it) {
         auto& direct_children = GetMemPoolChildren(main_it);
         for (txiter cit : direct_children) {
             if (first_pass) cit->already_touched(epoch);
@@ -105,6 +105,9 @@ void CTxMemPool::UpdateForDescendants(txiter updateIt, cacheMap &cachedDescendan
             }
         }
         first_pass = false;
+    };
+    do {
+        func(main_it);
     } while (!stack.empty() && (main_it = stack.back(), stack.pop_back(), true));
     mapTx.modify(updateIt, update_descendant_state(modifySize, modifyFee, modifyCount));
 }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -167,10 +167,10 @@ void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<uint256> &vHashes
 
 bool CTxMemPool::CalculateMemPoolAncestors(const CTxMemPoolEntry &entry, setEntries &setAncestors, uint64_t limitAncestorCount, uint64_t limitAncestorSize, uint64_t limitDescendantCount, uint64_t limitDescendantSize, std::string &errString, bool fSearchForParents /* = true */) const
 {
-    std::vector<txiter> parentHashes;
+    std::vector<txiter> ancestors;
     const CTransaction &tx = entry.GetTx();
+    const uint64_t epoch = GetFreshEpoch();
     if (fSearchForParents) {
-        const uint64_t epoch = GetFreshEpoch();
         // Get parents of this transaction that are in the mempool
         // GetMemPoolParents() is only valid for entries in the mempool, so we
         // iterate mapTx to find parents.
@@ -178,8 +178,8 @@ bool CTxMemPool::CalculateMemPoolAncestors(const CTxMemPoolEntry &entry, setEntr
             Optional<txiter> piter = GetIter(tx.vin[i].prevout.hash);
             if (piter) {
                 if ((*piter)->already_touched(epoch)) continue;
-                parentHashes.push_back(*piter);
-                if (parentHashes.size() + 1 > limitAncestorCount) {
+                ancestors.push_back(*piter);
+                if (ancestors.size() + 1 > limitAncestorCount) {
                     errString = strprintf("too many unconfirmed parents [limit: %u]", limitAncestorCount);
                     return false;
                 }
@@ -190,18 +190,20 @@ bool CTxMemPool::CalculateMemPoolAncestors(const CTxMemPoolEntry &entry, setEntr
         // entry in the mempool already.
         txiter it = mapTx.iterator_to(entry);
         auto& ref_parents = GetMemPoolParents(it);
-        parentHashes.assign(ref_parents.cbegin(), ref_parents.cend());
+        ancestors.assign(ref_parents.cbegin(), ref_parents.cend());
+        // touch before walking so we don't add a duplicate
+        for (txiter it : ancestors) {
+            it->already_touched(epoch);
+        }
     }
+
 
     size_t totalSizeWithAncestors = entry.GetTxSize();
 
-    const uint64_t epoch = GetFreshEpoch();
-    while (!parentHashes.empty()) {
-        txiter stageit = parentHashes.back();
-        stageit->already_touched(epoch);
-        parentHashes.pop_back();
+    size_t next_idx = 0;
+    while (next_idx < ancestors.size()) {
+        txiter stageit = ancestors[next_idx++];
 
-        setAncestors.insert(stageit);
         totalSizeWithAncestors += stageit->GetTxSize();
 
         if (stageit->GetSizeWithDescendants() + entry.GetTxSize() > limitDescendantSize) {
@@ -220,14 +222,16 @@ bool CTxMemPool::CalculateMemPoolAncestors(const CTxMemPoolEntry &entry, setEntr
             // If this is a new ancestor, add it.
             if (phash->already_touched(epoch)) continue;
             if (setAncestors.count(phash) == 0) {
-                parentHashes.push_back(phash);
+                ancestors.push_back(phash);
             }
-            if (parentHashes.size() + setAncestors.size() + 1 > limitAncestorCount) {
+            if (setAncestors.size() + ancestors.size() + 1 > limitAncestorCount) {
                 errString = strprintf("too many unconfirmed ancestors [limit: %u]", limitAncestorCount);
                 return false;
             }
         }
     }
+    // This is just to preserve the output type for now
+    for (txiter ancestor : ancestors) setAncestors.insert(ancestor);
 
     return true;
 }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -58,29 +58,17 @@ size_t CTxMemPoolEntry::GetTxSize() const
 // descendants.
 void CTxMemPool::UpdateForDescendants(txiter updateIt, cacheMap &cachedDescendants, const std::set<uint256> &setExclude)
 {
-    // Our children are natrually uniqueu
-    std::vector<txiter> stack;
-    uint64_t epoch = GetFreshEpoch();
-
-    int64_t modifySize = 0;
-    CAmount modifyFee = 0;
-    int64_t modifyCount = 0;
-    auto make_state_update = [&](txiter cit) {
-        if (!setExclude.count(cit->GetTx().GetHash())) {
-            modifySize += cit->GetTxSize();
-            modifyFee += cit->GetModifiedFee();
-            modifyCount++;
-            cachedDescendants[updateIt].insert(cit);
+    auto func = [this] (txiter param_it, txiter update_it, int64_t&size, CAmount& fee, int64_t& count, cacheMap& cache, const std::set<uint256>& exclude, std::vector<txiter>& stack, bool& first_pass, const uint64_t epoch) {
+        auto make_state_update = [&](txiter cit) {
+            if (exclude.count(cit->GetTx().GetHash())) return;
+            size += cit->GetTxSize();
+            fee += cit->GetModifiedFee();
+            count++;
+            cache[update_it].insert(cit);
             // Update ancestor state for each descendant
-            mapTx.modify(cit, update_ancestor_state(updateIt->GetTxSize(), updateIt->GetModifiedFee(), 1, updateIt->GetSigOpCost()));
-        }
-    };
-
-    // Update and add to cached descendant map
-    auto main_it = updateIt;
-    bool first_pass = true;
-    auto func = [&] (txiter param_it) {
-        auto& direct_children = GetMemPoolChildren(main_it);
+            mapTx.modify(cit, update_ancestor_state(update_it->GetTxSize(), update_it->GetModifiedFee(), 1, update_it->GetSigOpCost()));
+        };
+        auto& direct_children = GetMemPoolChildren(param_it);
         for (txiter cit : direct_children) {
             if (first_pass) cit->already_touched(epoch);
 
@@ -90,8 +78,8 @@ void CTxMemPool::UpdateForDescendants(txiter updateIt, cacheMap &cachedDescendan
             const setEntries &setChildren = GetMemPoolChildren(cit);
             for (txiter childEntry : setChildren) {
                 if (childEntry->already_touched(epoch)) continue;
-                cacheMap::iterator cacheIt = cachedDescendants.find(childEntry);
-                if (cacheIt != cachedDescendants.end()) {
+                cacheMap::iterator cacheIt = cache.find(childEntry);
+                if (cacheIt != cache.end()) {
                     // We've already calculated this one, just add the entries for this set
                     // but don't traverse again.
                     for (txiter cacheEntry : cacheIt->second) {
@@ -106,8 +94,19 @@ void CTxMemPool::UpdateForDescendants(txiter updateIt, cacheMap &cachedDescendan
         }
         first_pass = false;
     };
+    // Our children are natrually uniqueu
+    std::vector<txiter> stack;
+    uint64_t epoch = GetFreshEpoch();
+
+    int64_t modifySize = 0;
+    CAmount modifyFee = 0;
+    int64_t modifyCount = 0;
+
+    // Update and add to cached descendant map
+    auto main_it = updateIt;
+    bool first_pass = true;
     do {
-        func(main_it);
+        func(main_it, updateIt, modifySize, modifyFee, modifyCount, cachedDescendants, setExclude, stack, first_pass, epoch);
     } while (!stack.empty() && (main_it = stack.back(), stack.pop_back(), true));
     mapTx.modify(updateIt, update_descendant_state(modifySize, modifyFee, modifyCount));
 }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -450,6 +450,14 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
 // Also assumes that if an entry is in setDescendants already, then all
 // in-mempool descendants of it are already in setDescendants as well, so that we
 // can save time by not iterating over those entries.
+void CTxMemPool::CalculateDescendants(txiter it, setEntries& setDescendants, std::vector<txiter>& stack, const uint64_t epoch, const uint8_t limit) const {
+        for (txiter childiter : GetMemPoolChildren(it)) {
+            if (childiter->already_touched(epoch)) continue;
+            if (!setDescendants.insert(childiter).second) continue;
+            if (limit > 0) CalculateDescendants(childiter, setDescendants, stack, epoch, limit-1);
+            else stack.push_back(childiter);
+        }
+}
 void CTxMemPool::CalculateDescendants(txiter entryit, setEntries& setDescendants) const
 {
     if (!setDescendants.insert(entryit).second) return;
@@ -460,12 +468,7 @@ void CTxMemPool::CalculateDescendants(txiter entryit, setEntries& setDescendants
     txiter it = entryit;
     std::vector<txiter> stack;
     do {
-        const setEntries &setChildren = GetMemPoolChildren(it);
-        for (txiter childiter : setChildren) {
-            if (childiter->already_touched(epoch)) continue;
-            if (!setDescendants.insert(childiter).second) continue;
-            stack.push_back(childiter);
-        }
+        CalculateDescendants(it, setDescendants, stack, epoch);
     } while (!stack.empty() && (it = stack.back(), stack.pop_back(), true));
 
 }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -495,40 +495,48 @@ void CTxMemPool::removeRecursive(const CTransaction &origTx, MemPoolRemovalReaso
 {
     // Remove transaction from memory pool
     AssertLockHeld(cs);
-        setEntries txToRemove;
+        vecEntries txToRemove;
         txiter origit = mapTx.find(origTx.GetHash());
         if (origit != mapTx.end()) {
-            txToRemove.insert(origit);
+            txToRemove.push_back(origit);
         } else {
             // When recursively removing but origTx isn't in the mempool
             // be sure to remove any children that are in the pool. This can
             // happen during chain re-orgs if origTx isn't re-accepted into
             // the mempool for any reason.
+            const uint64_t epoch = GetFreshEpoch();
             for (unsigned int i = 0; i < origTx.vout.size(); i++) {
                 auto it = mapNextTx.find(COutPoint(origTx.GetHash(), i));
                 if (it == mapNextTx.end())
                     continue;
                 txiter nextit = mapTx.find(it->second->GetHash());
                 assert(nextit != mapTx.end());
-                txToRemove.insert(nextit);
+                if (nextit->already_touched(epoch)) continue;
+                txToRemove.push_back(nextit);
             }
         }
-        vecEntries all_removes;
         const uint64_t epoch = GetFreshEpoch();
+        // touch all txToRemove first to force CalculateDescendantsVec
+        // to not recurse if we're going to call it later.
+        // This guarantees txToRemove gets no duplicates
         for (txiter it : txToRemove) {
-            if (it->already_touched(epoch)) continue;
-            CalculateDescendantsVec(it, all_removes, epoch);
-            all_removes.push_back(it);
+            it->already_touched(epoch);
+        }
+        // max_idx is used rather than iterator because txToRemove may grow
+        const size_t max_idx = txToRemove.size();
+        for (size_t idx = 0; idx < max_idx; ++idx) {
+            CalculateDescendantsVec(txToRemove[idx], txToRemove, epoch);
         }
 
-        RemoveStaged(all_removes, false, reason);
+        RemoveStaged(txToRemove, false, reason);
 }
 
 void CTxMemPool::removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMemPoolHeight, int flags)
 {
     // Remove transactions spending a coinbase which are now immature and no-longer-final transactions
     AssertLockHeld(cs);
-    setEntries txToRemove;
+    vecEntries txToRemove;
+    // no need for an epoch or a set here since we only visit each it one time.
     for (indexed_transaction_set::const_iterator it = mapTx.begin(); it != mapTx.end(); it++) {
         const CTransaction& tx = it->GetTx();
         LockPoints lp = it->GetLockPoints();
@@ -536,7 +544,7 @@ void CTxMemPool::removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMem
         if (!CheckFinalTx(tx, flags) || !CheckSequenceLocks(*this, tx, flags, &lp, validLP)) {
             // Note if CheckSequenceLocks fails the LockPoints may still be invalid
             // So it's critical that we remove the tx and not depend on the LockPoints.
-            txToRemove.insert(it);
+            txToRemove.push_back(it);
         } else if (it->GetSpendsCoinbase()) {
             for (const CTxIn& txin : tx.vin) {
                 indexed_transaction_set::const_iterator it2 = mapTx.find(txin.prevout.hash);
@@ -545,7 +553,7 @@ void CTxMemPool::removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMem
                 const Coin &coin = pcoins->AccessCoin(txin.prevout);
                 if (nCheckFrequency != 0) assert(!coin.IsSpent());
                 if (coin.IsSpent() || (coin.IsCoinBase() && ((signed long)nMemPoolHeight) - coin.nHeight < COINBASE_MATURITY)) {
-                    txToRemove.insert(it);
+                    txToRemove.push_back(it);
                     break;
                 }
             }
@@ -554,14 +562,21 @@ void CTxMemPool::removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMem
             mapTx.modify(it, update_lock_points(lp));
         }
     }
-    vecEntries all_removes;
+
     const uint64_t epoch = GetFreshEpoch();
+    // touch all txToRemove first to force CalculateDescendantsVec
+    // to not recurse if we're going to call it later.
+    // This guarantees txToRemove gets no duplicates
     for (txiter it : txToRemove) {
-        if (it->already_touched(epoch)) continue;
-        CalculateDescendantsVec(it, all_removes, epoch);
-        all_removes.push_back(it);
+        it->already_touched(epoch);
     }
-    RemoveStaged(all_removes, false, MemPoolRemovalReason::REORG);
+    // max_idx is used rather than iterator because txToRemove may grow
+    const size_t max_idx = txToRemove.size();
+    for (size_t idx = 0; idx < max_idx; ++idx) {
+        CalculateDescendantsVec(txToRemove[idx], txToRemove, epoch);
+    }
+    RemoveStaged(txToRemove, false, MemPoolRemovalReason::REORG);
+
 }
 
 void CTxMemPool::removeConflicts(const CTransaction &tx)

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -77,37 +77,35 @@ void CTxMemPool::UpdateForDescendants(txiter updateIt, cacheMap &cachedDescendan
     };
 
     // Update and add to cached descendant map
-    auto& direct_children = GetMemPoolChildren(updateIt);
-    auto children_it = direct_children.begin();
-    while (children_it != direct_children.end() || !stack.empty()) {
-        // Either pop the stack or read from the direct_children
-        bool have_direct_children = children_it != direct_children.end();
-        const txiter cit =  have_direct_children ? *(children_it++) : stack.back();
-        // if on the stack already touched (but remove)
-        // touch the direct_children
-        if (!have_direct_children) stack.pop_back();
-        else cit->already_touched(epoch);
+    auto main_it = updateIt;
+    bool first_pass = true;
+    do {
+        auto& direct_children = GetMemPoolChildren(main_it);
+        for (txiter cit : direct_children) {
+            if (first_pass) cit->already_touched(epoch);
 
-        // collect stats
-        make_state_update(cit);
+            // collect stats
+            make_state_update(cit);
 
-        const setEntries &setChildren = GetMemPoolChildren(cit);
-        for (txiter childEntry : setChildren) {
-            if (childEntry->already_touched(epoch)) continue;
-            cacheMap::iterator cacheIt = cachedDescendants.find(childEntry);
-            if (cacheIt != cachedDescendants.end()) {
-                // We've already calculated this one, just add the entries for this set
-                // but don't traverse again.
-                for (txiter cacheEntry : cacheIt->second) {
-                    if (cacheEntry->already_touched(epoch)) continue;
-                    make_state_update(cacheEntry);
+            const setEntries &setChildren = GetMemPoolChildren(cit);
+            for (txiter childEntry : setChildren) {
+                if (childEntry->already_touched(epoch)) continue;
+                cacheMap::iterator cacheIt = cachedDescendants.find(childEntry);
+                if (cacheIt != cachedDescendants.end()) {
+                    // We've already calculated this one, just add the entries for this set
+                    // but don't traverse again.
+                    for (txiter cacheEntry : cacheIt->second) {
+                        if (cacheEntry->already_touched(epoch)) continue;
+                        make_state_update(cacheEntry);
+                    }
+                } else {
+                    // Schedule for later processing
+                    stack.push_back(childEntry);
                 }
-            } else {
-                // Schedule for later processing
-                stack.push_back(childEntry);
             }
         }
-    }
+        first_pass = false;
+    } while (!stack.empty() && (main_it = stack.back(), stack.pop_back(), true));
     mapTx.modify(updateIt, update_descendant_state(modifySize, modifyFee, modifyCount));
 }
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -484,16 +484,18 @@ void CTxMemPool::removeRecursive(const CTransaction &origTx, MemPoolRemovalReaso
 {
     // Remove transaction from memory pool
     AssertLockHeld(cs);
+        GetFreshEpoch();
         vecEntries txToRemove;
         txiter origit = mapTx.find(origTx.GetHash());
+        // All txToRemove will be touched, this guarantees txToRemove gets no duplicates
         if (origit != mapTx.end()) {
             txToRemove.push_back(origit);
+            already_touched(origit);
         } else {
             // When recursively removing but origTx isn't in the mempool
             // be sure to remove any children that are in the pool. This can
             // happen during chain re-orgs if origTx isn't re-accepted into
             // the mempool for any reason.
-            GetFreshEpoch();
             for (unsigned int i = 0; i < origTx.vout.size(); i++) {
                 auto it = mapNextTx.find(COutPoint(origTx.GetHash(), i));
                 if (it == mapNextTx.end())
@@ -503,13 +505,6 @@ void CTxMemPool::removeRecursive(const CTransaction &origTx, MemPoolRemovalReaso
                 if (already_touched(nextit)) continue;
                 txToRemove.push_back(nextit);
             }
-        }
-        GetFreshEpoch();
-        // touch all txToRemove first to force CalculateDescendantsVec
-        // to not recurse if we're going to call it later.
-        // This guarantees txToRemove gets no duplicates
-        for (txiter it : txToRemove) {
-            already_touched(it);
         }
         // max_idx is used rather than iterator because txToRemove may grow
         const size_t max_idx = txToRemove.size();

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -122,7 +122,7 @@ void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<uint256> &vHashes
     // UpdateForDescendants.
     for (const uint256 &hash : reverse_iterate(vHashesToUpdate)) {
         // we cache the in-mempool children to avoid duplicate updates
-        setEntries setChildren;
+        uint64_t epoch = GetFreshEpoch();
         // calculate children from mapNextTx
         txiter it = mapTx.find(hash);
         if (it == mapTx.end()) {
@@ -137,7 +137,7 @@ void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<uint256> &vHashes
             assert(childIter != mapTx.end());
             // We can skip updating entries we've encountered before or that
             // are in the block (which are already accounted for).
-            if (setChildren.insert(childIter).second && !setAlreadyIncluded.count(childHash)) {
+            if (!childIter->already_touched(epoch) && !setAlreadyIncluded.count(childHash)) {
                 UpdateChild(it, childIter, true);
                 UpdateParent(childIter, it, true);
             }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1301,3 +1301,4 @@ CTxMemPool::EpochGuard::~EpochGuard()
 }
 
 SaltedTxidHasher::SaltedTxidHasher() : k0(GetRand(std::numeric_limits<uint64_t>::max())), k1(GetRand(std::numeric_limits<uint64_t>::max())) {}
+SaltedUInt32Hasher::SaltedUInt32Hasher() : a(GetRand(std::numeric_limits<uint64_t>::max())){}

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -232,7 +232,7 @@ bool CTxMemPool::CalculateMemPoolAncestors(const CTxMemPoolEntry &entry, vecEntr
     return true;
 }
 
-void CTxMemPool::UpdateAncestorsOf(bool add, txiter it, vecEntries &setAncestors)
+void CTxMemPool::UpdateAncestorsOf(bool add, txiter it, vecEntries &ancestors)
 {
     setEntries parentIters = GetMemPoolParents(it);
     // add or remove this tx as a child of each parent
@@ -242,18 +242,18 @@ void CTxMemPool::UpdateAncestorsOf(bool add, txiter it, vecEntries &setAncestors
     const int64_t updateCount = (add ? 1 : -1);
     const int64_t updateSize = updateCount * it->GetTxSize();
     const CAmount updateFee = updateCount * it->GetModifiedFee();
-    for (txiter ancestorIt : setAncestors) {
+    for (txiter ancestorIt : ancestors) {
         mapTx.modify(ancestorIt, update_descendant_state(updateSize, updateFee, updateCount));
     }
 }
 
-void CTxMemPool::UpdateEntryForAncestors(txiter it, const vecEntries &setAncestors)
+void CTxMemPool::UpdateEntryForAncestors(txiter it, const vecEntries &ancestors)
 {
-    int64_t updateCount = setAncestors.size();
+    int64_t updateCount = ancestors.size();
     int64_t updateSize = 0;
     CAmount updateFee = 0;
     int64_t updateSigOpsCost = 0;
-    for (txiter ancestorIt : setAncestors) {
+    for (txiter ancestorIt : ancestors) {
         updateSize += ancestorIt->GetTxSize();
         updateFee += ancestorIt->GetModifiedFee();
         updateSigOpsCost += ancestorIt->GetSigOpCost();
@@ -294,7 +294,7 @@ void CTxMemPool::UpdateForRemoveFromMempoolImpl(const T &entriesToRemove, bool u
         }
     }
     for (txiter removeIt : entriesToRemove) {
-        vecEntries setAncestors;
+        vecEntries ancestors;
         const CTxMemPoolEntry &entry = *removeIt;
         std::string dummy;
         // Since this is a tx that is already in the mempool, we can call CMPA
@@ -314,10 +314,10 @@ void CTxMemPool::UpdateForRemoveFromMempoolImpl(const T &entriesToRemove, bool u
         // differ from the set of mempool parents we'd calculate by searching,
         // and it's important that we use the mapLinks[] notion of ancestor
         // transactions as the set of things to update for removal.
-        CalculateMemPoolAncestors(entry, setAncestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy, false);
+        CalculateMemPoolAncestors(entry, ancestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy, false);
         // Note that UpdateAncestorsOf severs the child links that point to
         // removeIt in the entries for the parents of removeIt.
-        UpdateAncestorsOf(false, removeIt, setAncestors);
+        UpdateAncestorsOf(false, removeIt, ancestors);
     }
     // After updating all the ancestor sizes, we can now sever the link between each
     // transaction being removed and any mempool children (ie, update setMemPoolParents
@@ -381,7 +381,7 @@ void CTxMemPool::AddTransactionsUpdated(unsigned int n)
     nTransactionsUpdated += n;
 }
 
-void CTxMemPool::addUnchecked(const CTxMemPoolEntry &entry, vecEntries &setAncestors, bool validFeeEstimate)
+void CTxMemPool::addUnchecked(const CTxMemPoolEntry &entry, vecEntries &ancestors, bool validFeeEstimate)
 {
     NotifyEntryAdded(entry.GetSharedTx());
     // Add to memory pool without checking anything.
@@ -420,8 +420,8 @@ void CTxMemPool::addUnchecked(const CTxMemPoolEntry &entry, vecEntries &setAnces
     // to clean up the mess we're leaving here.
 
     // Update ancestors with information about this tx
-    UpdateAncestorsOf(true, newit, setAncestors);
-    UpdateEntryForAncestors(newit, setAncestors);
+    UpdateAncestorsOf(true, newit, ancestors);
+    UpdateEntryForAncestors(newit, ancestors);
 
     nTransactionsUpdated++;
     totalTxSize += entry.GetTxSize();
@@ -715,16 +715,16 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
         }
         assert(setParentCheck == GetMemPoolParents(it));
         // Verify ancestor state is correct.
-        vecEntries setAncestors;
+        vecEntries ancestors;
         uint64_t nNoLimit = std::numeric_limits<uint64_t>::max();
         std::string dummy;
-        CalculateMemPoolAncestors(*it, setAncestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy);
-        uint64_t nCountCheck = setAncestors.size() + 1;
+        CalculateMemPoolAncestors(*it, ancestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy);
+        uint64_t nCountCheck = ancestors.size() + 1;
         uint64_t nSizeCheck = it->GetTxSize();
         CAmount nFeesCheck = it->GetModifiedFee();
         int64_t nSigOpCheck = it->GetSigOpCost();
 
-        for (txiter ancestorIt : setAncestors) {
+        for (txiter ancestorIt : ancestors) {
             nSizeCheck += ancestorIt->GetTxSize();
             nFeesCheck += ancestorIt->GetModifiedFee();
             nSigOpCheck += ancestorIt->GetSigOpCost();
@@ -886,11 +886,11 @@ void CTxMemPool::PrioritiseTransaction(const uint256& hash, const CAmount& nFeeD
         if (it != mapTx.end()) {
             mapTx.modify(it, update_fee_delta(delta));
             // Now update all ancestors' modified fees with descendants
-            vecEntries setAncestors;
+            vecEntries ancestors;
             uint64_t nNoLimit = std::numeric_limits<uint64_t>::max();
             std::string dummy;
-            CalculateMemPoolAncestors(*it, setAncestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy, false);
-            for (txiter ancestorIt : setAncestors) {
+            CalculateMemPoolAncestors(*it, ancestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy, false);
+            for (txiter ancestorIt : ancestors) {
                 mapTx.modify(ancestorIt, update_descendant_state(0, nFeeDelta, 0));
             }
             // Now update all descendants' modified fees with ancestors
@@ -1014,11 +1014,11 @@ int CTxMemPool::Expire(std::chrono::seconds time)
 
 void CTxMemPool::addUnchecked(const CTxMemPoolEntry &entry, bool validFeeEstimate)
 {
-    vecEntries setAncestors;
+    vecEntries ancestors;
     uint64_t nNoLimit = std::numeric_limits<uint64_t>::max();
     std::string dummy;
-    CalculateMemPoolAncestors(entry, setAncestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy);
-    return addUnchecked(entry, setAncestors, validFeeEstimate);
+    CalculateMemPoolAncestors(entry, ancestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy);
+    return addUnchecked(entry, ancestors, validFeeEstimate);
 }
 
 void CTxMemPool::UpdateChild(txiter entry, txiter child, bool add)

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -516,9 +516,9 @@ void CTxMemPool::removeRecursive(const CTransaction &origTx, MemPoolRemovalReaso
         vecEntries all_removes;
         const uint64_t epoch = GetFreshEpoch();
         for (txiter it : txToRemove) {
+            if (it->already_touched(epoch)) continue;
             CalculateDescendantsVec(it, all_removes, epoch);
-            if (!it->already_touched(epoch))
-                all_removes.push_back(it);
+            all_removes.push_back(it);
         }
 
         RemoveStaged(all_removes, false, reason);
@@ -557,9 +557,9 @@ void CTxMemPool::removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMem
     vecEntries all_removes;
     const uint64_t epoch = GetFreshEpoch();
     for (txiter it : txToRemove) {
+        if (it->already_touched(epoch)) continue;
         CalculateDescendantsVec(it, all_removes, epoch);
-        if (!it->already_touched(epoch))
-                all_removes.push_back(it);
+        all_removes.push_back(it);
     }
     RemoveStaged(all_removes, false, MemPoolRemovalReason::REORG);
 }

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -627,7 +627,7 @@ public:
      */
     template <typename T>
     void RemoveStagedImpl(T& stage, bool updateDescendants, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
-    void RemoveStaged(std::vector<txiter>& stage, bool updateDescendants, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void RemoveStaged(vecEntries& stage, bool updateDescendants, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
     void RemoveStaged(setEntries& stage, bool updateDescendants, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** When adding transactions from a disconnected block back to the mempool,
@@ -662,11 +662,11 @@ public:
      *  iterate over them and don't care about order
      *
      * CalculateDescendantsVec does not include self (it)*/
-    void CalculateDescendantsVec(txiter it, std::vector<txiter>& descendants, std::vector<txiter>& stack,
+    void CalculateDescendantsVec(txiter it, vecEntries& descendants, vecEntries& stack,
             const uint64_t epoch, const uint8_t limit=25) const EXCLUSIVE_LOCKS_REQUIRED(cs);
-    /** Assumes setDescednants is empty */
-    void CalculateDescendantsVec(txiter it, std::vector<txiter>& setDescendants) const EXCLUSIVE_LOCKS_REQUIRED(cs);
-    void CalculateDescendantsVec(txiter entryit, std::vector<txiter>& setDescendants, const uint64_t cached_epoch) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    /** Assumes descednants is empty */
+    void CalculateDescendantsVec(txiter it, vecEntries& descendants) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void CalculateDescendantsVec(txiter entryit, vecEntries& descendants, const uint64_t cached_epoch) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** The minimum fee to get into the mempool, which may itself not be enough
       *  for larger-sized transactions.
@@ -742,7 +742,7 @@ private:
             cacheMap &cachedDescendants,
             const std::set<uint256> &setExclude) EXCLUSIVE_LOCKS_REQUIRED(cs);
     void UpdateForDescendantsInner(txiter param_it, txiter update_it, int64_t&size, CAmount& fee,
-            int64_t& count, cacheMap& cache, const std::set<uint256>& exclude, std::vector<txiter>&
+            int64_t& count, cacheMap& cache, const std::set<uint256>& exclude, vecEntries&
             stack, bool update_child_epochs, const uint64_t epoch, const uint8_t limit = 25) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Update ancestors of hash to add/remove it as a descendant transaction. */
     void UpdateAncestorsOf(bool add, txiter hash, vecEntries &ancestors) EXCLUSIVE_LOCKS_REQUIRED(cs);
@@ -753,8 +753,8 @@ private:
       * ancestor state. */
     template <typename T>
     void UpdateForRemoveFromMempoolImpl(const T &entriesToRemove, bool updateDescendants) EXCLUSIVE_LOCKS_REQUIRED(cs);
-    void UpdateForRemoveFromMempool(const std::vector<txiter> &entriesToRemove, bool updateDescendants) EXCLUSIVE_LOCKS_REQUIRED(cs);
-    void UpdateForRemoveFromMempool(const setEntries &entriesToRemove, bool updateDescendants) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void UpdateForRemoveFromMempool(const vecEntries& entriesToRemove, bool updateDescendants) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void UpdateForRemoveFromMempool(const setEntries& entriesToRemove, bool updateDescendants) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Sever link between specified transaction and direct children. */
     void UpdateChildrenForRemoval(txiter entry) EXCLUSIVE_LOCKS_REQUIRED(cs);
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -656,6 +656,7 @@ public:
     void CalculateDescendants(txiter it, setEntries& setDescendants, std::vector<txiter>& stack,
             const uint64_t epoch, const uint8_t limit=25) const EXCLUSIVE_LOCKS_REQUIRED(cs);
     void CalculateDescendants(txiter it, setEntries& setDescendants) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void CalculateDescendants(txiter entryit, setEntries& setDescendants, const uint64_t cached_epoch) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** The minimum fee to get into the mempool, which may itself not be enough
       *  for larger-sized transactions.

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -131,14 +131,7 @@ public:
     int64_t GetSigOpCostWithAncestors() const { return nSigOpCostWithAncestors; }
 
     mutable size_t vTxHashesIdx; //!< Index in mempool's vTxHashes
-private:
     mutable uint64_t m_epoch; //!< epoch when last touched, useful for graph algorithms
-public:
-    bool already_touched(uint64_t during) const {
-        bool ret = m_epoch >= during;
-        m_epoch = std::max(m_epoch, during);
-        return ret;
-    }
 };
 
 // Helpers for modifying CTxMemPool::mapTx, which is a boost multi_index.
@@ -653,17 +646,16 @@ public:
     /** Populate descendants with all in-mempool descendants of hash.
      *
      *  Assumes that if descendants includes a txiter T, then all in-mempool descendants of T are
-     *  already in it and T->already_touched(cached_epoch)
+     *  already in it and already_touched(T)
      *
      *  Assumes empty descendants vector. Useful when we are just going to
      *  iterate over them and don't care about order
      *
      * CalculateDescendantsVec does not include self (it)*/
     void CalculateDescendantsVec(txiter it, vecEntries& descendants, vecEntries& stack,
-            const uint64_t epoch, const uint8_t limit=25) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+            const uint8_t limit=25) const EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Assumes descednants is empty */
     void CalculateDescendantsVec(txiter it, vecEntries& descendants) const EXCLUSIVE_LOCKS_REQUIRED(cs);
-    void CalculateDescendantsVec(txiter entryit, vecEntries& descendants, const uint64_t cached_epoch) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** The minimum fee to get into the mempool, which may itself not be enough
       *  for larger-sized transactions.
@@ -740,7 +732,7 @@ private:
             const std::set<uint256> &setExclude) EXCLUSIVE_LOCKS_REQUIRED(cs);
     void UpdateForDescendantsInner(txiter param_it, txiter update_it, int64_t&size, CAmount& fee,
             int64_t& count, cacheMap& cache, const std::set<uint256>& exclude, vecEntries&
-            stack, bool update_child_epochs, const uint64_t epoch, const uint8_t limit = 25) EXCLUSIVE_LOCKS_REQUIRED(cs);
+            stack, bool update_child_epochs, const uint8_t limit = 25) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Update ancestors of hash to add/remove it as a descendant transaction. */
     void UpdateAncestorsOf(bool add, txiter hash, vecEntries &ancestors) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Set ancestor state for an entry */
@@ -764,6 +756,23 @@ private:
 public:
     // This function mutates mutable state!
     uint64_t GetFreshEpoch() const EXCLUSIVE_LOCKS_REQUIRED(cs);
+
+    bool already_touched(txiter it, uint64_t during) const EXCLUSIVE_LOCKS_REQUIRED(cs) {
+        bool ret = it->m_epoch >= during;
+        it->m_epoch = std::max(it->m_epoch, during);
+        return ret;
+    }
+    bool already_touched(Optional<txiter> it, uint64_t during) const EXCLUSIVE_LOCKS_REQUIRED(cs) {
+        return !it || already_touched(*it, during);
+    }
+    bool already_touched(txiter it) const EXCLUSIVE_LOCKS_REQUIRED(cs) {
+        bool ret = it->m_epoch >= m_epoch;
+        it->m_epoch = std::max(it->m_epoch, m_epoch);
+        return ret;
+    }
+    bool already_touched(Optional<txiter> it) const EXCLUSIVE_LOCKS_REQUIRED(cs) {
+        return !it || already_touched(*it);
+    }
 };
 
 /**

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -514,8 +514,11 @@ private:
     CBlockPolicyEstimator* minerPolicyEstimator;
 
     uint64_t totalTxSize;      //!< sum of all mempool tx's virtual sizes. Differs from serialized tx size since witness data is discounted. Defined in BIP 141.
-    uint64_t cachedInnerUsage; //!< sum of dynamic memory usage of all the map elements (NOT the maps themselves)
-    uint64_t cachedInnerMapNextTxSize = 0;
+    uint64_t cachedInnerUsageEntry; //!< sum of dynamic memory usage of all the parent map elements (NOT the maps themselves)
+    uint64_t cachedInnerUsageParents; //!< sum of dynamic memory usage of all the parent map elements (NOT the maps themselves)
+    uint64_t cachedInnerUsageChildren; //!< sum of dynamic memory usage of all the children map elements (NOT the maps themselves)
+    uint64_t cachedInnerUsageMapNextTx; //!< sum of dynamic memory usage of all the mapNextTx map elements (NOT the maps themselves)
+    uint64_t cachedInnerMapNextTxSize; //!< count of number of UTXOs mapped in mapNextTx
 
     mutable int64_t lastRollingFeeUpdate;
     mutable bool blockSinceLastRollingFeeBump;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -131,6 +131,14 @@ public:
     int64_t GetSigOpCostWithAncestors() const { return nSigOpCostWithAncestors; }
 
     mutable size_t vTxHashesIdx; //!< Index in mempool's vTxHashes
+private:
+    mutable uint64_t m_epoch; //!< epoch when last touched, useful for graph algorithms
+public:
+    bool already_touched(uint64_t during) const {
+        bool ret = m_epoch >= during;
+        m_epoch = std::max(m_epoch, during);
+        return ret;
+    }
 };
 
 // Helpers for modifying CTxMemPool::mapTx, which is a boost multi_index.
@@ -455,6 +463,7 @@ private:
     mutable int64_t lastRollingFeeUpdate;
     mutable bool blockSinceLastRollingFeeBump;
     mutable double rollingMinimumFeeRate; //!< minimum fee to get into the pool, decreases exponentially
+    mutable uint64_t m_epoch;
 
     void trackPackageRemoved(const CFeeRate& rate) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
@@ -738,6 +747,9 @@ private:
      *  removal.
      */
     void removeUnchecked(txiter entry, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
+public:
+    // This function mutates mutable state!
+    uint64_t GetFreshEpoch() const EXCLUSIVE_LOCKS_REQUIRED(cs);
 };
 
 /**

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -76,6 +76,20 @@ struct EqualIteratorByHash {
     }
 };
 
+class SaltedUInt32Hasher
+{
+private:
+    uint64_t a;
+public:
+    SaltedUInt32Hasher();
+    // the std::hash<uint32_t> returns
+    // the integer itself, so it's fine that
+    // we're up-casting a uint32_t here
+    size_t operator()(const uint32_t x) const {
+        return HalfSipHashUint32(a,x);
+    }
+};
+
 class SaltedTxidHasher
 {
 private:
@@ -596,7 +610,7 @@ private:
 public:
     // N.B.: because unordered_node<std::pair<uint32_t, txiter>> is 4 bytes then 8 bytes then 8 bytes for pointer, we end up
     // with 24 bytes rather than 20 bytes. Perhaps these extra 4 bytes in a map are useful sometime down the line.
-    std::unordered_map<uint256, std::unordered_map<uint32_t, const txiter>, SaltedTxidHasher> mapNextTx GUARDED_BY(cs);
+    std::unordered_map<uint256, std::unordered_map<uint32_t, const txiter, SaltedUInt32Hasher>, SaltedTxidHasher> mapNextTx GUARDED_BY(cs);
     std::map<uint256, CAmount> mapDeltas;
 
     /** Create a new CTxMemPool.

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -625,10 +625,7 @@ public:
      *  Set updateDescendants to true when removing a tx that was in a block, so
      *  that any in-mempool descendants have their ancestor state updated.
      */
-    template <typename T>
-    void RemoveStagedImpl(T& stage, bool updateDescendants, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
     void RemoveStaged(vecEntries& stage, bool updateDescendants, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
-    void RemoveStaged(setEntries& stage, bool updateDescendants, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** When adding transactions from a disconnected block back to the mempool,
      *  new mempool entries may have children in the mempool (which is generally
@@ -751,10 +748,7 @@ private:
     /** For each transaction being removed, update ancestors and any direct children.
       * If updateDescendants is true, then also update in-mempool descendants'
       * ancestor state. */
-    template <typename T>
-    void UpdateForRemoveFromMempoolImpl(const T &entriesToRemove, bool updateDescendants) EXCLUSIVE_LOCKS_REQUIRED(cs);
     void UpdateForRemoveFromMempool(const vecEntries& entriesToRemove, bool updateDescendants) EXCLUSIVE_LOCKS_REQUIRED(cs);
-    void UpdateForRemoveFromMempool(const setEntries& entriesToRemove, bool updateDescendants) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Sever link between specified transaction and direct children. */
     void UpdateChildrenForRemoval(txiter entry) EXCLUSIVE_LOCKS_REQUIRED(cs);
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -584,7 +584,7 @@ public:
     // and any other callers may break wallet's in-mempool tracking (due to
     // lack of CValidationInterface::TransactionAddedToMempool callbacks).
     void addUnchecked(const CTxMemPoolEntry& entry, bool validFeeEstimate = true) EXCLUSIVE_LOCKS_REQUIRED(cs, cs_main);
-    void addUnchecked(const CTxMemPoolEntry& entry, vecEntries& setAncestors, bool validFeeEstimate = true) EXCLUSIVE_LOCKS_REQUIRED(cs, cs_main);
+    void addUnchecked(const CTxMemPoolEntry& entry, vecEntries& ancestors, bool validFeeEstimate = true) EXCLUSIVE_LOCKS_REQUIRED(cs, cs_main);
 
     void removeRecursive(const CTransaction& tx, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
     void removeForReorg(const CCoinsViewCache* pcoins, unsigned int nMemPoolHeight, int flags) EXCLUSIVE_LOCKS_REQUIRED(cs, cs_main);
@@ -651,7 +651,7 @@ public:
      *  fSearchForParents = whether to search a tx's vin for in-mempool parents, or
      *    look up parents from mapLinks. Must be true for entries not in the mempool
      */
-    bool CalculateMemPoolAncestors(const CTxMemPoolEntry& entry, vecEntries& setAncestors, uint64_t limitAncestorCount, uint64_t limitAncestorSize, uint64_t limitDescendantCount, uint64_t limitDescendantSize, std::string& errString, bool fSearchForParents = true) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    bool CalculateMemPoolAncestors(const CTxMemPoolEntry& entry, vecEntries& ancestors, uint64_t limitAncestorCount, uint64_t limitAncestorSize, uint64_t limitDescendantCount, uint64_t limitDescendantSize, std::string& errString, bool fSearchForParents = true) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** Populate setDescendants with all in-mempool descendants of hash.
      *  Assumes that setDescendants includes all in-mempool descendants of anything
@@ -747,9 +747,9 @@ private:
             int64_t& count, cacheMap& cache, const std::set<uint256>& exclude, std::vector<txiter>&
             stack, bool update_child_epochs, const uint64_t epoch, const uint8_t limit = 25) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Update ancestors of hash to add/remove it as a descendant transaction. */
-    void UpdateAncestorsOf(bool add, txiter hash, vecEntries &setAncestors) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void UpdateAncestorsOf(bool add, txiter hash, vecEntries &ancestors) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Set ancestor state for an entry */
-    void UpdateEntryForAncestors(txiter it, const vecEntries &setAncestors) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void UpdateEntryForAncestors(txiter it, const vecEntries &ancestors) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** For each transaction being removed, update ancestors and any direct children.
       * If updateDescendants is true, then also update in-mempool descendants'
       * ancestor state. */

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -658,6 +658,14 @@ public:
     void CalculateDescendants(txiter it, setEntries& setDescendants) const EXCLUSIVE_LOCKS_REQUIRED(cs);
     void CalculateDescendants(txiter entryit, setEntries& setDescendants, const uint64_t cached_epoch) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
+    /* Assumes empty descendants vector. Useful when we are just going to iterate over them
+     *
+     * unlike CalculateDescendants, CalculateDescendantsVec does not include self*/
+    void CalculateDescendantsVec(txiter it, std::vector<txiter>& descendants, std::vector<txiter>& stack,
+            const uint64_t epoch, const uint8_t limit=25) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void CalculateDescendantsVec(txiter it, std::vector<txiter>& setDescendants) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void CalculateDescendantsVec(txiter entryit, std::vector<txiter>& setDescendants, const uint64_t cached_epoch) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+
     /** The minimum fee to get into the mempool, which may itself not be enough
       *  for larger-sized transactions.
       *  The incrementalRelayFee policy variable is used to bound the time it

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -653,9 +653,6 @@ public:
      *  iterate over them and don't care about order
      *
      * CalculateDescendantsVec does not include self (it)*/
-    void CalculateDescendantsVec(txiter it, vecEntries& descendants, vecEntries& stack,
-            const uint8_t limit=25) const EXCLUSIVE_LOCKS_REQUIRED(cs);
-    /** Assumes descednants is empty */
     void CalculateDescendantsVec(txiter it, vecEntries& descendants) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** The minimum fee to get into the mempool, which may itself not be enough

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -439,7 +439,7 @@ public:
  * in-block transactions by calling UpdateTransactionsFromBlock().  Note that
  * until this is called, the mempool state is not consistent, and in particular
  * mapLinks may not be correct (and therefore functions like
- * CalculateMemPoolAncestors() and CalculateDescendants() that rely
+ * CalculateMemPoolAncestors() and CalculateDescendantsVec() that rely
  * on them to walk the mempool are not generally safe to use).
  *
  * Computational limits:
@@ -653,20 +653,18 @@ public:
      */
     bool CalculateMemPoolAncestors(const CTxMemPoolEntry& entry, vecEntries& ancestors, uint64_t limitAncestorCount, uint64_t limitAncestorSize, uint64_t limitDescendantCount, uint64_t limitDescendantSize, std::string& errString, bool fSearchForParents = true) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
-    /** Populate setDescendants with all in-mempool descendants of hash.
-     *  Assumes that setDescendants includes all in-mempool descendants of anything
-     *  already in it.  */
-
-    void CalculateDescendants(txiter it, setEntries& setDescendants, std::vector<txiter>& stack,
-            const uint64_t epoch, const uint8_t limit=25) const EXCLUSIVE_LOCKS_REQUIRED(cs);
-    void CalculateDescendants(txiter it, setEntries& setDescendants) const EXCLUSIVE_LOCKS_REQUIRED(cs);
-    void CalculateDescendants(txiter entryit, setEntries& setDescendants, const uint64_t cached_epoch) const EXCLUSIVE_LOCKS_REQUIRED(cs);
-
-    /* Assumes empty descendants vector. Useful when we are just going to iterate over them
+    /** Populate descendants with all in-mempool descendants of hash.
      *
-     * unlike CalculateDescendants, CalculateDescendantsVec does not include self*/
+     *  Assumes that if descendants includes a txiter T, then all in-mempool descendants of T are
+     *  already in it and T->already_touched(cached_epoch)
+     *
+     *  Assumes empty descendants vector. Useful when we are just going to
+     *  iterate over them and don't care about order
+     *
+     * CalculateDescendantsVec does not include self (it)*/
     void CalculateDescendantsVec(txiter it, std::vector<txiter>& descendants, std::vector<txiter>& stack,
             const uint64_t epoch, const uint8_t limit=25) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    /** Assumes setDescednants is empty */
     void CalculateDescendantsVec(txiter it, std::vector<txiter>& setDescendants) const EXCLUSIVE_LOCKS_REQUIRED(cs);
     void CalculateDescendantsVec(txiter entryit, std::vector<txiter>& setDescendants, const uint64_t cached_epoch) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -727,6 +727,9 @@ private:
     void UpdateForDescendants(txiter updateIt,
             cacheMap &cachedDescendants,
             const std::set<uint256> &setExclude) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void UpdateForDescendantsInner(txiter param_it, txiter update_it, int64_t&size, CAmount& fee,
+            int64_t& count, cacheMap& cache, const std::set<uint256>& exclude, std::vector<txiter>&
+            stack, bool update_child_epochs, const uint64_t epoch, const uint8_t limit = 25) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Update ancestors of hash to add/remove it as a descendant transaction. */
     void UpdateAncestorsOf(bool add, txiter hash, setEntries &setAncestors) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Set ancestor state for an entry */

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -565,6 +565,8 @@ public:
 
     uint64_t CalculateDescendantMaximum(txiter entry) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 private:
+    uint64_t CalculateDescendantMaximumInner(std::reference_wrapper<const CTxMemPoolEntry> candidate,
+            std::vector<std::reference_wrapper<const CTxMemPoolEntry>>& candidates, uint64_t maximum, uint8_t limit) const EXCLUSIVE_LOCKS_REQUIRED(cs);
     typedef std::unordered_map<txiter, std::vector<txiter>, SaltedTxidHasher, EqualIteratorByHash> cacheMap;
 
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -538,6 +538,7 @@ public:
         }
     };
     typedef std::set<txiter, CompareIteratorByHash> setEntries;
+    typedef std::vector<txiter> vecEntries;
 
     const setEntries & GetMemPoolParents(txiter entry) const EXCLUSIVE_LOCKS_REQUIRED(cs);
     const setEntries & GetMemPoolChildren(txiter entry) const EXCLUSIVE_LOCKS_REQUIRED(cs);
@@ -583,7 +584,7 @@ public:
     // and any other callers may break wallet's in-mempool tracking (due to
     // lack of CValidationInterface::TransactionAddedToMempool callbacks).
     void addUnchecked(const CTxMemPoolEntry& entry, bool validFeeEstimate = true) EXCLUSIVE_LOCKS_REQUIRED(cs, cs_main);
-    void addUnchecked(const CTxMemPoolEntry& entry, setEntries& setAncestors, bool validFeeEstimate = true) EXCLUSIVE_LOCKS_REQUIRED(cs, cs_main);
+    void addUnchecked(const CTxMemPoolEntry& entry, vecEntries& setAncestors, bool validFeeEstimate = true) EXCLUSIVE_LOCKS_REQUIRED(cs, cs_main);
 
     void removeRecursive(const CTransaction& tx, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
     void removeForReorg(const CCoinsViewCache* pcoins, unsigned int nMemPoolHeight, int flags) EXCLUSIVE_LOCKS_REQUIRED(cs, cs_main);
@@ -650,7 +651,7 @@ public:
      *  fSearchForParents = whether to search a tx's vin for in-mempool parents, or
      *    look up parents from mapLinks. Must be true for entries not in the mempool
      */
-    bool CalculateMemPoolAncestors(const CTxMemPoolEntry& entry, setEntries& setAncestors, uint64_t limitAncestorCount, uint64_t limitAncestorSize, uint64_t limitDescendantCount, uint64_t limitDescendantSize, std::string& errString, bool fSearchForParents = true) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    bool CalculateMemPoolAncestors(const CTxMemPoolEntry& entry, vecEntries& setAncestors, uint64_t limitAncestorCount, uint64_t limitAncestorSize, uint64_t limitDescendantCount, uint64_t limitDescendantSize, std::string& errString, bool fSearchForParents = true) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** Populate setDescendants with all in-mempool descendants of hash.
      *  Assumes that setDescendants includes all in-mempool descendants of anything
@@ -746,9 +747,9 @@ private:
             int64_t& count, cacheMap& cache, const std::set<uint256>& exclude, std::vector<txiter>&
             stack, bool update_child_epochs, const uint64_t epoch, const uint8_t limit = 25) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Update ancestors of hash to add/remove it as a descendant transaction. */
-    void UpdateAncestorsOf(bool add, txiter hash, setEntries &setAncestors) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void UpdateAncestorsOf(bool add, txiter hash, vecEntries &setAncestors) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Set ancestor state for an entry */
-    void UpdateEntryForAncestors(txiter it, const setEntries &setAncestors) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void UpdateEntryForAncestors(txiter it, const vecEntries &setAncestors) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** For each transaction being removed, update ancestors and any direct children.
       * If updateDescendants is true, then also update in-mempool descendants'
       * ancestor state. */

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -457,6 +457,7 @@ private:
     mutable bool blockSinceLastRollingFeeBump;
     mutable double rollingMinimumFeeRate; //!< minimum fee to get into the pool, decreases exponentially
     mutable uint64_t m_epoch;
+    mutable bool has_epoch_guard;
 
     void trackPackageRemoved(const CFeeRate& rate) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
@@ -755,9 +756,16 @@ private:
     void removeUnchecked(txiter entry, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
 public:
     // This function mutates mutable state!
-    uint64_t GetFreshEpoch() const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    class EpochGuard {
+        const CTxMemPool& pool;
+        public:
+        EpochGuard(const CTxMemPool& in);
+        ~EpochGuard();
+    };
+    EpochGuard GetFreshEpoch() const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     bool already_touched(txiter it, uint64_t during) const EXCLUSIVE_LOCKS_REQUIRED(cs) {
+        assert(has_epoch_guard);
         bool ret = it->m_epoch >= during;
         it->m_epoch = std::max(it->m_epoch, during);
         return ret;
@@ -766,6 +774,7 @@ public:
         return !it || already_touched(*it, during);
     }
     bool already_touched(txiter it) const EXCLUSIVE_LOCKS_REQUIRED(cs) {
+        assert(has_epoch_guard);
         bool ret = it->m_epoch >= m_epoch;
         it->m_epoch = std::max(it->m_epoch, m_epoch);
         return ret;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -652,6 +652,9 @@ public:
     /** Populate setDescendants with all in-mempool descendants of hash.
      *  Assumes that setDescendants includes all in-mempool descendants of anything
      *  already in it.  */
+
+    void CalculateDescendants(txiter it, setEntries& setDescendants, std::vector<txiter>& stack,
+            const uint64_t epoch, const uint8_t limit=25) const EXCLUSIVE_LOCKS_REQUIRED(cs);
     void CalculateDescendants(txiter it, setEntries& setDescendants) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** The minimum fee to get into the mempool, which may itself not be enough

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -624,6 +624,9 @@ public:
      *  Set updateDescendants to true when removing a tx that was in a block, so
      *  that any in-mempool descendants have their ancestor state updated.
      */
+    template <typename T>
+    void RemoveStagedImpl(T& stage, bool updateDescendants, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void RemoveStaged(std::vector<txiter>& stage, bool updateDescendants, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
     void RemoveStaged(setEntries& stage, bool updateDescendants, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** When adding transactions from a disconnected block back to the mempool,
@@ -749,6 +752,9 @@ private:
     /** For each transaction being removed, update ancestors and any direct children.
       * If updateDescendants is true, then also update in-mempool descendants'
       * ancestor state. */
+    template <typename T>
+    void UpdateForRemoveFromMempoolImpl(const T &entriesToRemove, bool updateDescendants) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void UpdateForRemoveFromMempool(const std::vector<txiter> &entriesToRemove, bool updateDescendants) EXCLUSIVE_LOCKS_REQUIRED(cs);
     void UpdateForRemoveFromMempool(const setEntries &entriesToRemove, bool updateDescendants) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Sever link between specified transaction and direct children. */
     void UpdateChildrenForRemoval(txiter entry) EXCLUSIVE_LOCKS_REQUIRED(cs);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -575,7 +575,7 @@ private:
     std::vector<indexed_transaction_set::const_iterator> GetSortedDepthAndScore() const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
 public:
-    indirectmap<COutPoint, const CTransaction*> mapNextTx GUARDED_BY(cs);
+    indirectmap<COutPoint, const txiter> mapNextTx GUARDED_BY(cs);
     std::map<uint256, CAmount> mapDeltas;
 
     /** Create a new CTxMemPool.
@@ -625,13 +625,10 @@ public:
     void ClearPrioritisation(const uint256 hash);
 
     /** Get the transaction in the pool that spends the same prevout */
-    const CTransaction* GetConflictTx(const COutPoint& prevout) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    const Optional<txiter> GetConflictTx(const COutPoint& prevout) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** Returns an iterator to the given hash, if found */
     Optional<txiter> GetIter(const uint256& txid) const EXCLUSIVE_LOCKS_REQUIRED(cs);
-
-    /** Translate a set of hashes into a set of pool iterators to avoid repeated lookups */
-    setEntries GetIterSet(const std::set<uint256>& hashes) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** Remove a set of transactions from the mempool.
      *  If a transaction is in this set, then all in-mempool descendants must

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -764,21 +764,13 @@ public:
     };
     EpochGuard GetFreshEpoch() const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
-    bool already_touched(txiter it, uint64_t during) const EXCLUSIVE_LOCKS_REQUIRED(cs) {
-        assert(has_epoch_guard);
-        bool ret = it->m_epoch >= during;
-        it->m_epoch = std::max(it->m_epoch, during);
-        return ret;
-    }
-    bool already_touched(Optional<txiter> it, uint64_t during) const EXCLUSIVE_LOCKS_REQUIRED(cs) {
-        return !it || already_touched(*it, during);
-    }
     bool already_touched(txiter it) const EXCLUSIVE_LOCKS_REQUIRED(cs) {
         assert(has_epoch_guard);
         bool ret = it->m_epoch >= m_epoch;
         it->m_epoch = std::max(it->m_epoch, m_epoch);
         return ret;
     }
+
     bool already_touched(Optional<txiter> it) const EXCLUSIVE_LOCKS_REQUIRED(cs) {
         return !it || already_touched(*it);
     }

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -554,7 +554,7 @@ public:
 
     uint64_t CalculateDescendantMaximum(txiter entry) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 private:
-    typedef std::map<txiter, setEntries, CompareIteratorByHash> cacheMap;
+    typedef std::map<txiter, std::vector<txiter>, SaltedTxidHasher, EqualIteratorByHash> cacheMap;
 
 
 
@@ -738,9 +738,6 @@ private:
     void UpdateForDescendants(txiter updateIt,
             cacheMap &cachedDescendants,
             const std::set<uint256> &setExclude) EXCLUSIVE_LOCKS_REQUIRED(cs);
-    void UpdateForDescendantsInner(txiter param_it, txiter update_it, int64_t&size, CAmount& fee,
-            int64_t& count, cacheMap& cache, const std::set<uint256>& exclude, vecEntries&
-            stack, bool update_child_epochs, const uint8_t limit = 25) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Update ancestors of hash to add/remove it as a descendant transaction. */
     void UpdateAncestorsOf(bool add, txiter hash, vecEntries &ancestors) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Set ancestor state for an entry */

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -836,10 +836,10 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         if (nConflictingCount <= maxDescendantsToVisit) {
             // If not too many to replace, then calculate the set of
             // transactions that would have to be evicted
-            const uint64_t epoch = m_pool.GetFreshEpoch();
+            m_pool.GetFreshEpoch();
             for (CTxMemPool::txiter it : setIterConflicting) {
-                if (it->already_touched(epoch)) continue;
-                m_pool.CalculateDescendantsVec(it, all_conflicting, epoch);
+                if (m_pool.already_touched(it)) continue;
+                m_pool.CalculateDescendantsVec(it, all_conflicting);
                 all_conflicting.push_back(it);
             }
             for (CTxMemPool::txiter it : all_conflicting) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -836,7 +836,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         if (nConflictingCount <= maxDescendantsToVisit) {
             // If not too many to replace, then calculate the set of
             // transactions that would have to be evicted
-            m_pool.GetFreshEpoch();
+            const auto epoch = m_pool.GetFreshEpoch();
             for (CTxMemPool::txiter it : setIterConflicting) {
                 if (m_pool.already_touched(it)) continue;
                 m_pool.CalculateDescendantsVec(it, all_conflicting);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -467,7 +467,7 @@ private:
         Workspace(const CTransactionRef& ptx) : m_ptx(ptx), m_hash(ptx->GetHash()) {}
         std::set<uint256> m_conflicts;
         CTxMemPool::setEntries m_all_conflicting;
-        CTxMemPool::setEntries m_ancestors;
+        CTxMemPool::vecEntries m_ancestors;
         std::unique_ptr<CTxMemPoolEntry> m_entry;
 
         bool m_replacement_transaction;
@@ -545,7 +545,8 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     // Alias what we need out of ws
     std::set<uint256>& setConflicts = ws.m_conflicts;
     CTxMemPool::setEntries& allConflicting = ws.m_all_conflicting;
-    CTxMemPool::setEntries& setAncestors = ws.m_ancestors;
+    CTxMemPool::vecEntries& setAncestors = ws.m_ancestors;
+    assert(setAncestors.empty());
     std::unique_ptr<CTxMemPoolEntry>& entry = ws.m_entry;
     bool& fReplacementTransaction = ws.m_replacement_transaction;
     CAmount& nModifiedFees = ws.m_modified_fees;
@@ -966,7 +967,7 @@ bool MemPoolAccept::Finalize(ATMPArgs& args, Workspace& ws)
     const bool bypass_limits = args.m_bypass_limits;
 
     CTxMemPool::setEntries& allConflicting = ws.m_all_conflicting;
-    CTxMemPool::setEntries& setAncestors = ws.m_ancestors;
+    CTxMemPool::vecEntries& setAncestors = ws.m_ancestors;
     const CAmount& nModifiedFees = ws.m_modified_fees;
     const CAmount& nConflictingFees = ws.m_conflicting_fees;
     const size_t& nConflictingSize = ws.m_conflicting_size;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -466,7 +466,7 @@ private:
     struct Workspace {
         Workspace(const CTransactionRef& ptx) : m_ptx(ptx), m_hash(ptx->GetHash()) {}
         std::set<uint256> m_conflicts;
-        CTxMemPool::setEntries m_all_conflicting;
+        CTxMemPool::vecEntries m_all_conflicting;
         CTxMemPool::vecEntries m_ancestors;
         std::unique_ptr<CTxMemPoolEntry> m_entry;
 
@@ -544,7 +544,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
 
     // Alias what we need out of ws
     std::set<uint256>& setConflicts = ws.m_conflicts;
-    CTxMemPool::setEntries& allConflicting = ws.m_all_conflicting;
+    CTxMemPool::vecEntries& all_conflicting = ws.m_all_conflicting;
     CTxMemPool::vecEntries& ancestors = ws.m_ancestors;
     assert(ancestors.empty());
     std::unique_ptr<CTxMemPoolEntry>& entry = ws.m_entry;
@@ -789,7 +789,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     nConflictingSize = 0;
     uint64_t nConflictingCount = 0;
 
-    // If we don't hold the lock allConflicting might be incomplete; the
+    // If we don't hold the lock all_conflicting might be incomplete; the
     // subsequent RemoveStaged() and addUnchecked() calls don't guarantee
     // mempool consistency for us.
     fReplacementTransaction = setConflicts.size();
@@ -836,10 +836,13 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         if (nConflictingCount <= maxDescendantsToVisit) {
             // If not too many to replace, then calculate the set of
             // transactions that would have to be evicted
+            const uint64_t epoch = m_pool.GetFreshEpoch();
             for (CTxMemPool::txiter it : setIterConflicting) {
-                m_pool.CalculateDescendants(it, allConflicting);
+                if (it->already_touched(epoch)) continue;
+                m_pool.CalculateDescendantsVec(it, all_conflicting, epoch);
+                all_conflicting.push_back(it);
             }
-            for (CTxMemPool::txiter it : allConflicting) {
+            for (CTxMemPool::txiter it : all_conflicting) {
                 nConflictingFees += it->GetModifiedFee();
                 nConflictingSize += it->GetTxSize();
             }
@@ -966,7 +969,7 @@ bool MemPoolAccept::Finalize(ATMPArgs& args, Workspace& ws)
     TxValidationState &state = args.m_state;
     const bool bypass_limits = args.m_bypass_limits;
 
-    CTxMemPool::setEntries& allConflicting = ws.m_all_conflicting;
+    CTxMemPool::vecEntries& all_conflicting = ws.m_all_conflicting;
     CTxMemPool::vecEntries& ancestors = ws.m_ancestors;
     const CAmount& nModifiedFees = ws.m_modified_fees;
     const CAmount& nConflictingFees = ws.m_conflicting_fees;
@@ -975,7 +978,7 @@ bool MemPoolAccept::Finalize(ATMPArgs& args, Workspace& ws)
     std::unique_ptr<CTxMemPoolEntry>& entry = ws.m_entry;
 
     // Remove conflicting transactions from the mempool
-    for (CTxMemPool::txiter it : allConflicting)
+    for (CTxMemPool::txiter it : all_conflicting)
     {
         LogPrint(BCLog::MEMPOOL, "replacing tx %s with %s for %s BTC additional fees, %d delta bytes\n",
                 it->GetTx().GetHash().ToString(),
@@ -985,7 +988,7 @@ bool MemPoolAccept::Finalize(ATMPArgs& args, Workspace& ws)
         if (args.m_replaced_transactions)
             args.m_replaced_transactions->push_back(it->GetSharedTx());
     }
-    m_pool.RemoveStaged(allConflicting, false, MemPoolRemovalReason::REPLACED);
+    m_pool.RemoveStaged(all_conflicting, false, MemPoolRemovalReason::REPLACED);
 
     // This transaction should only count for fee estimation if:
     // - it isn't a BIP 125 replacement transaction (may not be widely supported)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -545,8 +545,8 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     // Alias what we need out of ws
     std::set<uint256>& setConflicts = ws.m_conflicts;
     CTxMemPool::setEntries& allConflicting = ws.m_all_conflicting;
-    CTxMemPool::vecEntries& setAncestors = ws.m_ancestors;
-    assert(setAncestors.empty());
+    CTxMemPool::vecEntries& ancestors = ws.m_ancestors;
+    assert(ancestors.empty());
     std::unique_ptr<CTxMemPoolEntry>& entry = ws.m_entry;
     bool& fReplacementTransaction = ws.m_replacement_transaction;
     CAmount& nModifiedFees = ws.m_modified_fees;
@@ -746,8 +746,8 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     }
 
     std::string errString;
-    if (!m_pool.CalculateMemPoolAncestors(*entry, setAncestors, m_limit_ancestors, m_limit_ancestor_size, m_limit_descendants, m_limit_descendant_size, errString)) {
-        setAncestors.clear();
+    if (!m_pool.CalculateMemPoolAncestors(*entry, ancestors, m_limit_ancestors, m_limit_ancestor_size, m_limit_descendants, m_limit_descendant_size, errString)) {
+        ancestors.clear();
         // If CalculateMemPoolAncestors fails second time, we want the original error string.
         std::string dummy_err_string;
         // Contracting/payment channels CPFP carve-out:
@@ -762,16 +762,16 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         // outputs - one for each counterparty. For more info on the uses for
         // this, see https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2018-November/016518.html
         if (nSize >  EXTRA_DESCENDANT_TX_SIZE_LIMIT ||
-                !m_pool.CalculateMemPoolAncestors(*entry, setAncestors, 2, m_limit_ancestor_size, m_limit_descendants + 1, m_limit_descendant_size + EXTRA_DESCENDANT_TX_SIZE_LIMIT, dummy_err_string)) {
+                !m_pool.CalculateMemPoolAncestors(*entry, ancestors, 2, m_limit_ancestor_size, m_limit_descendants + 1, m_limit_descendant_size + EXTRA_DESCENDANT_TX_SIZE_LIMIT, dummy_err_string)) {
             return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "too-long-mempool-chain", errString);
         }
     }
 
     // A transaction that spends outputs that would be replaced by it is invalid. Now
     // that we have the set of all ancestors we can detect this
-    // pathological case by making sure setConflicts and setAncestors don't
+    // pathological case by making sure setConflicts and ancestors don't
     // intersect.
-    for (CTxMemPool::txiter ancestorIt : setAncestors)
+    for (CTxMemPool::txiter ancestorIt : ancestors)
     {
         const uint256 &hashAncestor = ancestorIt->GetTx().GetHash();
         if (setConflicts.count(hashAncestor))
@@ -967,7 +967,7 @@ bool MemPoolAccept::Finalize(ATMPArgs& args, Workspace& ws)
     const bool bypass_limits = args.m_bypass_limits;
 
     CTxMemPool::setEntries& allConflicting = ws.m_all_conflicting;
-    CTxMemPool::vecEntries& setAncestors = ws.m_ancestors;
+    CTxMemPool::vecEntries& ancestors = ws.m_ancestors;
     const CAmount& nModifiedFees = ws.m_modified_fees;
     const CAmount& nConflictingFees = ws.m_conflicting_fees;
     const size_t& nConflictingSize = ws.m_conflicting_size;
@@ -995,7 +995,7 @@ bool MemPoolAccept::Finalize(ATMPArgs& args, Workspace& ws)
     bool validForFeeEstimation = !fReplacementTransaction && !bypass_limits && IsCurrentForFeeEstimation() && m_pool.HasNoInputsOf(tx);
 
     // Store transaction in memory
-    m_pool.addUnchecked(*entry, setAncestors, validForFeeEstimation);
+    m_pool.addUnchecked(*entry, ancestors, validForFeeEstimation);
 
     // trim mempool and check if tx was trimmed
     if (!bypass_limits) {


### PR DESCRIPTION
Removing mapLinks following mempool-experiments-2.

This is 3x faster than master on the benchmark, and about 1.4x faster than mempool-experiments-2.



![image](https://user-images.githubusercontent.com/886523/67920199-80eda180-fb60-11e9-9658-26fcbf17e7d6.png)


The CTxMemPoolEntry::relatives are still std::set's for now, but they can be made hashmaps (I'm working on such a modification). However, because the stress test has a limited constant number of children or parents per level, it does not show a performance difference from std::set (this is good -- it shows we're at least not *slower* for the extra hashing. Once the additional tests which more aggressively hit the relatives sets are generated/tested/graphed for master, mempool-experiments-2, and mempool-experiments-2-withoutMapLinks, and the new branch and show a notable improvement, I'll follow up with that as a PR onto this branch.