### PR TITLE
Fix compilation errors

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1136,7 +1136,7 @@ static UniValue sendmanycompacted(const JSONRPCRequest& request)
     std::set<CTxDestination> destinations;
 
     // The multiset keeps the items in vecSend sorted by weight
-    const auto cmp = [](const std::pair<double, CTxOut>& a, const std::pair<double, CTxOut>& b) bool {
+    const auto cmp = [](const std::pair<double, CTxOut>& a, const std::pair<double, CTxOut>& b) -> bool {
             return a.first < b.first;
             };
     std::multiset<std::pair<double, CTxOut>, decltype(cmp)> vecSend(cmp);
@@ -1326,7 +1326,7 @@ static UniValue sendmanycompacted(const JSONRPCRequest& request)
     UniValue outpoint(UniValue::VOBJ);
     outpoint.pushKV("hash", tx->GetHash().ToString());
     outpoint.pushKV("n", 0);
-    metadata.pushKV("radix", radix);
+    metadata.pushKV("radix", int(radix));
 
     UniValue ret(UniValue::VOBJ);
     ret.pushKV("metadata", metadata);


### PR DESCRIPTION
I was getting some compilation errors when building the `checktemplateverify-feb1-workshop` branch:

```
$ make
Making all in src
  CXX      wallet/libbitcoin_wallet_a-rpcwallet.o
wallet/rpcwallet.cpp:1139:97: error: expected body of lambda expression
    const auto cmp = [](const std::pair<double, CTxOut>& a, const std::pair<double, CTxOut>& b) bool {
                                                                                                ^
wallet/rpcwallet.cpp:1142:61: error: unknown type name 'vecSend'
    std::multiset<std::pair<double, CTxOut>, decltype(cmp)> vecSend(cmp);
                                                            ^
wallet/rpcwallet.cpp:1161:9: error: use of undeclared identifier 'vecSend'
        vecSend.emplace((sort_keys_it++)->first, recipient);
        ^
wallet/rpcwallet.cpp:1173:26: error: use of undeclared identifier 'vecSend'
        for (auto& txo : vecSend) {
                         ^
wallet/rpcwallet.cpp:1190:9: error: use of undeclared identifier 'vecSend'
        vecSend.clear();
        ^
wallet/rpcwallet.cpp:1198:9: error: use of undeclared identifier 'vecSend'
        vecSend.emplace(0, CTxOut(base.vout[0].nValue + base.vout[1].nValue, script));
        ^
wallet/rpcwallet.cpp:1203:16: error: use of undeclared identifier 'vecSend'
        while (vecSend.size() > 1) {
               ^
wallet/rpcwallet.cpp:1209:51: error: use of undeclared identifier 'vecSend'
            const size_t pieces = std::min(radix, vecSend.size());
                                                  ^
wallet/rpcwallet.cpp:1218:34: error: use of undeclared identifier 'vecSend'
                    auto start = vecSend.begin();
                                 ^
wallet/rpcwallet.cpp:1219:32: error: use of undeclared identifier 'vecSend'
                    auto end = vecSend.begin();
                               ^
wallet/rpcwallet.cpp:1222:21: error: use of undeclared identifier 'vecSend'
                    vecSend.erase(start, end);
                    ^
wallet/rpcwallet.cpp:1225:34: error: use of undeclared identifier 'vecSend'
                    auto start = vecSend.rbegin();
                                 ^
wallet/rpcwallet.cpp:1226:32: error: use of undeclared identifier 'vecSend'
                    auto end = vecSend.rbegin();
                               ^
wallet/rpcwallet.cpp:1229:21: error: use of undeclared identifier 'vecSend'
                    vecSend.erase(std::prev(start.base()), vecSend.end());
                    ^
wallet/rpcwallet.cpp:1229:60: error: use of undeclared identifier 'vecSend'
                    vecSend.erase(std::prev(start.base()), vecSend.end());
                                                           ^
wallet/rpcwallet.cpp:1232:30: error: use of undeclared identifier 'vecSend'
                auto start = vecSend.begin();
                             ^
wallet/rpcwallet.cpp:1233:28: error: use of undeclared identifier 'vecSend'
                auto end = vecSend.begin();
                           ^
wallet/rpcwallet.cpp:1236:17: error: use of undeclared identifier 'vecSend'
                vecSend.erase(start, end);
                ^
wallet/rpcwallet.cpp:1254:13: error: use of undeclared identifier 'vecSend'
            vecSend.emplace(new_weight, CTxOut(amount, CScript() << h_buff << OP_CHECKTEMPLATEVERIFY));
            ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
make[2]: *** [wallet/libbitcoin_wallet_a-rpcwallet.o] Error 1
make[1]: *** [all-recursive] Error 1
make: *** [all-recursive] Error 1
```

Fixing the lambda by adding `->` leads to one more error:
```
$ make
Making all in src
  CXX      wallet/libbitcoin_wallet_a-rpcwallet.o
wallet/rpcwallet.cpp:1329:14: error: call to member function 'pushKV' is ambiguous
    metadata.pushKV("radix", radix);
    ~~~~~~~~~^~~~~~
./univalue/include/univalue.h:123:10: note: candidate function
    bool pushKV(const std::string& key, int64_t val_) {
         ^
./univalue/include/univalue.h:127:10: note: candidate function
    bool pushKV(const std::string& key, uint64_t val_) {
         ^
./univalue/include/univalue.h:131:10: note: candidate function
    bool pushKV(const std::string& key, bool val_) {
         ^
./univalue/include/univalue.h:135:10: note: candidate function
    bool pushKV(const std::string& key, int val_) {
         ^
./univalue/include/univalue.h:139:10: note: candidate function
    bool pushKV(const std::string& key, double val_) {
         ^
./univalue/include/univalue.h:114:10: note: candidate function
    bool pushKV(const std::string& key, const UniValue& val);
         ^
./univalue/include/univalue.h:115:10: note: candidate function not viable: no known conversion from 'size_t' (aka 'unsigned long') to 'const std::string' (aka 'const basic_string<char, char_traits<char>, allocator<char> >') for 2nd argument
    bool pushKV(const std::string& key, const std::string& val_) {
         ^
./univalue/include/univalue.h:119:10: note: candidate function not viable: no known conversion from 'size_t' (aka 'unsigned long') to 'const char *' for 2nd argument
    bool pushKV(const std::string& key, const char *val_) {
         ^
1 error generated.
make[2]: *** [wallet/libbitcoin_wallet_a-rpcwallet.o] Error 1
make[1]: *** [all-recursive] Error 1
make: *** [all-recursive] Error 1
```

Adding the cast fixes that one.

With these fixes, I was able to get bitcoind built and running successfully.

Here's my system info for reference:
```
$ /usr/local/bin/ccache gcc --version
Configured with: --prefix=/Library/Developer/CommandLineTools/usr --with-gxx-include-dir=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/4.2.1
Apple clang version 11.0.0 (clang-1100.0.33.17)
Target: x86_64-apple-darwin19.3.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```

<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
